### PR TITLE
added Swedish ÅÄÖ as valid input keys

### DIFF
--- a/src/PowerShellRun/Application/SearchBar.cs
+++ b/src/PowerShellRun/Application/SearchBar.cs
@@ -22,14 +22,14 @@ internal class SearchBar
 
     public int CursorXInCanvas
     {
-        get 
+        get
         {
             return _cursorX + _textBox.X;
         }
     }
     public int CursorYInCanvas
     {
-        get 
+        get
         {
             return _textBox.Y;
         }
@@ -49,7 +49,7 @@ internal class SearchBar
         int borderHeight = theme.SearchBarBorderFlags.HasFlag(BorderFlag.Top) ? 1 : 0;
         borderHeight += theme.SearchBarBorderFlags.HasFlag(BorderFlag.Bottom) ? 1 : 0;
         RootLayout.LayoutSizeHeight.Set(LayoutSizeType.Absolute, 1 + borderHeight);
-        
+
         int promptLength = TextBox.GetDisplayWidth(promptString);
         _prompt.OnlyStoreLinesInVisibleRange = false;
         _prompt.LayoutSizeWidth.Set(LayoutSizeType.Absolute, promptLength);
@@ -182,13 +182,15 @@ internal class SearchBar
                 }
                 continue;
             }
-
-            if (!Char.IsAscii(key.ConsoleKeyInfo.KeyChar))
+            // old method if !Char.IsAscii(key.ConsoleKeyInfo.KeyChar) does not allow for non-ascii characters.
+            if (!Enum.IsDefined(typeof(Key), key.KeyCombination.Key) && (key.ConsoleKeyInfo.KeyChar < 0 || key.ConsoleKeyInfo.KeyChar > 127))
+            {
                 continue;
-
+            }
             if (_readKeysBuffer.Length >= Constants.QueryCharacterMaxCount)
+            {
                 continue;
-
+            }
             if (_cursorX == _readKeysBuffer.Length)
             {
                 _readKeysBuffer.Append(key.ConsoleKeyInfo.KeyChar);

--- a/src/PowerShellRun/Base/Key.cs
+++ b/src/PowerShellRun/Base/Key.cs
@@ -4,7 +4,7 @@ using System.Text;
 
 public class KeyCombination : DeepCloneable
 {
-    public KeyModifier Modifier 
+    public KeyModifier Modifier
     {
         get => _modifier;
         set
@@ -67,7 +67,7 @@ public class KeyCombination : DeepCloneable
         KeyCombination other = (KeyCombination)obj;
         return Modifier == other.Modifier && Key == other.Key;
     }
-    
+
     public override int GetHashCode()
     {
         return (Modifier, Key).GetHashCode();
@@ -104,7 +104,7 @@ public class KeyCombination : DeepCloneable
             }
             builder.Append(Key.ToString());
         }
-        
+
         _string = builder.ToString();
     }
 
@@ -224,7 +224,9 @@ public enum Key
     X,
     Y,
     Z,
-   
+    Å,
+    Ä,
+    Ö,
     F1,
     F2,
     F3,

--- a/src/PowerShellRun/Base/KeyInput.cs
+++ b/src/PowerShellRun/Base/KeyInput.cs
@@ -102,7 +102,7 @@ internal sealed class KeyInput : Singleton<KeyInput>
         return new KeyCombination(modifier, key);
     }
 
-    private static (Key Key, ConsoleKey ConsoleKey)[] _keyConsoleKeyTable = 
+    private static (Key Key, ConsoleKey ConsoleKey)[] _keyConsoleKeyTable =
     {
         (Key.Backspace, ConsoleKey.Backspace),
         (Key.Tab, ConsoleKey.Tab),
@@ -156,6 +156,9 @@ internal sealed class KeyInput : Singleton<KeyInput>
         (Key.X, ConsoleKey.X),
         (Key.Y, ConsoleKey.Y),
         (Key.Z, ConsoleKey.Z),
+        (Key.Å, ConsoleKey.Oem6),
+        (Key.Ä, ConsoleKey.Oem7),
+        (Key.Ö, ConsoleKey.Oem3),
 
         (Key.F1, ConsoleKey.F1),
         (Key.F2, ConsoleKey.F2),


### PR DESCRIPTION
Hey,

Cool module, i noticed that 'Å','Ä','Ö' was not allowed as input..

I added them to the enum and `_keyConsoleKeyTable`, i had to modify the `IsAscii` check a bit cause otherwise it wouldn't allow them..

I'm sure theres many more missing.

I think trying to keep this up to date over time could be quite hard.

would probably be easier to just defer to .net using something like:

https://learn.microsoft.com/en-us/dotnet/api/system.io.path.getinvalidfilenamechars?view=net-8.0
https://learn.microsoft.com/en-us/dotnet/api/system.io.path.getinvalidpathchars?view=net-8.0

