### PR TITLE
Idea for "Always" registries

### DIFF
--- a/module/PowerShellRun/Private/GlobalStore.ps1
+++ b/module/PowerShellRun/Private/GlobalStore.ps1
@@ -6,6 +6,7 @@ class GlobalStore {
     $functionRegistry
     $applicationRegistry
     $fileSystemRegistry
+    $wingetRegistry
 
     $parentSelectorRestoreRequest = $false
     $originalPSConsoleHostReadLine = $null
@@ -25,6 +26,7 @@ class GlobalStore {
         $this.functionRegistry = New-Object FunctionRegistry
         $this.applicationRegistry = New-Object ApplicationRegistry
         $this.fileSystemRegistry = New-Object FileSystemRegistry
+        $this.wingetRegistry = New-Object WingetRegistry
     }
 
     [void] Terminate() {
@@ -77,6 +79,7 @@ class GlobalStore {
         $this.applicationRegistry.EnableEntries($entryCategories)
         $this.functionRegistry.EnableEntries($entryCategories)
         $this.fileSystemRegistry.EnableEntries($entryCategories)
+        $this.wingetRegistry.EnableEntries($entryCategories)
     }
 
     [void] UpdateEntries() {
@@ -84,6 +87,7 @@ class GlobalStore {
         $updated = $this.applicationRegistry.UpdateEntries() -or $updated
         $updated = $this.functionRegistry.UpdateEntries() -or $updated
         $updated = $this.fileSystemRegistry.UpdateEntries() -or $updated
+        $updated = $this.wingetRegistry.UpdateEntries() -or $updated
 
         if ($updated) {
             $this.entries.Clear()
@@ -94,6 +98,9 @@ class GlobalStore {
                 $this.entries.AddRange($_entries)
             }
             if ($_entries = $this.applicationRegistry.GetEntries()) {
+                $this.entries.AddRange($_entries)
+            }
+            if ($_entries = $this.wingetRegistry.GetEntries()) {
                 $this.entries.AddRange($_entries)
             }
         }

--- a/module/PowerShellRun/Private/WingetRegistry.ps1
+++ b/module/PowerShellRun/Private/WingetRegistry.ps1
@@ -107,7 +107,7 @@ class WingetRegistry {
             # Strip winget from the query if it was used as a prefix to trigger the search
             $query = $result.Context.Query -replace '^\s*winget\s+(.+)', '$1'
 
-            $option.Prompt = "https://winget.run/ results for packages matching '$query'> "
+            $option.Prompt = "Winget results for packages matching '$query'> "
 
             $entries = [System.Collections.Generic.List[PowerShellRun.SelectorEntry]]::new()
             $addEntry = {

--- a/module/PowerShellRun/Private/WingetRegistry.ps1
+++ b/module/PowerShellRun/Private/WingetRegistry.ps1
@@ -1,0 +1,172 @@
+class WingetRegistry {
+    $wingetEntry = [System.Collections.Generic.List[PowerShellRun.SelectorEntry]]::new()
+
+    $isWingetEnabled = $false
+    $isEntryUpdated = $false
+
+    [ScriptBlock]$defaultEditorScript
+    $wingetArguments
+
+    WingetRegistry() {
+        $this.defaultEditorScript = {
+            param ($item)
+            Write-Host 'Not configured'
+        }
+
+        $this.wingetArguments = @{
+            This = $this
+            ActionKeys = @(
+                [PowerShellRun.ActionKey]::new($script:globalStore.firstActionKey, 'Install with winget')
+                [PowerShellRun.ActionKey]::new($script:globalStore.secondActionKey, 'View details in winget.run')
+                [PowerShellRun.ActionKey]::new($script:globalStore.copyActionKey, 'Copy install command to Clipboard')
+            )
+            PreviewScript = {
+                param ($item)
+                $preview = @(
+                    "$($PSStyle.Underline)Install:$($PSStyle.UnderlineOff)     winget install --exact --id $($item.Id)"
+                    "$($PSStyle.Underline)Name:$($PSStyle.UnderlineOff)        $($item.Latest.Name)"
+                    "$($PSStyle.Underline)Publisher:$($PSStyle.UnderlineOff)   $($item.Latest.Publisher)"
+                    "$($PSStyle.Underline)Homepage:$($PSStyle.UnderlineOff)    $($item.Latest.Homepage)"
+                    "$($PSStyle.Underline)Description:$($PSStyle.UnderlineOff) $($item.Latest.Description -replace '\. ', ".`n             ")"
+                )
+                $preview -join "`n" | Out-String
+            }
+        }
+    }
+
+    static [System.Collections.Generic.List[object]] SearchWinget([string] $Query) {
+        try {
+            $result = Invoke-WebRequest -Method 'GET' -Uri 'https://api.winget.run/v2/packages' -Body @{
+                ensureContains = 'true'
+                partialMatch = 'true'
+                take = '10'
+                query = [System.Web.HttpUtility]::UrlEncode($Query)
+                order = '1'
+            }
+
+            # Response is not valid json, rename some duplicate properties and convert to json
+            $result = $result.Content -creplace 'createdAt', '_createdAt' -replace 'updatedAt', '_updatedAt'
+            $result = $result | ConvertFrom-Json -ErrorAction SilentlyContinue
+
+            return $result.Packages
+        } catch {
+            # Need a way to indicate the registry failed to respond
+            return @()
+        }
+    }
+
+    [System.Collections.Generic.List[PowerShellRun.SelectorEntry]] GetEntries() {
+        $entries = [System.Collections.Generic.List[PowerShellRun.SelectorEntry]]::new()
+        if ($this.isWingetEnabled) {
+            $entries.AddRange($this.wingetEntry)
+        }
+        return $entries
+    }
+
+    [void] EnableEntries([String[]]$categories) {
+        $this.isEntryUpdated = $true
+
+        $this.isWingetEnabled = $categories -contains 'Installer'
+        $this.wingetEntry.Clear()
+        if ($this.isWingetEnabled) {
+            $this.RegisterWingetEntry()
+        }
+    }
+
+    [void] RegisterWingetEntry() {
+        $callback = {
+            $result = $args[0].Result
+            $arguments = $args[0].ArgumentList
+
+            if ($result.KeyCombination -eq $script:globalStore.firstActionKey) {
+                & $arguments.This.wingetLoop $result $arguments
+            } elseif ($result.KeyCombination -eq $script:globalStore.copyActionKey) {
+                "winget install '$($result | ConvertTo-Json)'" | Set-Clipboard
+            }
+        }
+
+        $entry = [PowerShellRun.SelectorEntry]::new()
+        $entry.Icon = '🔍'
+        $entry.Name = 'Search Winget (PSRun)'
+        $entry.Description = 'Search available winget packages and install them.'
+        $entry.ActionKeys = @(
+            [PowerShellRun.ActionKey]::new($script:globalStore.firstActionKey, 'Explore winget packages')
+        )
+
+        # Could be named better, this entry is always shown with a score of one to ensure you can choose to use it to trigger an action on what's in the psrun prompt
+        $entry.AlwaysAvailable = $true
+
+        $entry.UserData = @{
+            ScriptBlock = $callback
+            ArgumentList = $this.wingetArguments
+        }
+
+        $this.wingetEntry.Add($entry)
+    }
+
+    $wingetLoop = {
+        param($result, $arguments)
+
+        $option = $script:globalStore.psRunSelectorOption.DeepClone()
+        $option.QuitWithBackspaceOnEmptyQuery = $true
+
+        $distance = 0
+        while ($true) {
+            $option.Prompt = "https://winget.run/ results for packages matching '$($result.Context.Query)'> "
+
+            $entries = [System.Collections.Generic.List[PowerShellRun.SelectorEntry]]::new()
+            $addEntry = {
+                param($item, $name, $icon)
+                $entry = [PowerShellRun.SelectorEntry]::new()
+                $entry.UserData = $item
+                $entry.Name = $name
+                $entry.Icon = '📦'
+                $entry.PreviewAsyncScript = $arguments.PreviewScript
+                $entry.ActionKeys = $arguments.ActionKeys
+                $entry.PreviewAsyncScriptArgumentList = $item
+                $entries.Add($entry)
+            }
+
+            [WingetRegistry]::SearchWinget($result.Context.Query) | ForEach-Object {
+                $addEntry.Invoke($_, $_.Latest.Name)
+            }
+
+            $result = Invoke-PSRunSelectorCustom -Entry $entries -Option $option
+
+            if ($result.KeyCombination -eq 'Backspace') {
+                if ($distance -eq 0) {
+                    Restore-PSRunFunctionParentSelector
+                    break
+                } else {
+                    $distance--
+                    continue
+                }
+            }
+
+            if (-not $result.FocusedEntry) {
+                break
+            }
+
+            $item = $result.FocusedEntry.UserData
+            if ($result.KeyCombination -eq $script:globalStore.firstActionKey) {
+                & winget install --id "$($item.Id)"
+                break
+            } elseif ($result.KeyCombination -eq $script:globalStore.secondActionKey) {
+                Start-Process "https://example.com/$($item.Id)"
+                break
+            } elseif ($result.KeyCombination -eq $script:globalStore.copyActionKey) {
+                $item.ToString() | Set-Clipboard
+                break
+            } else {
+                break
+            }
+        }
+    }
+
+    [bool] UpdateEntries() {
+        $updated = $this.isEntryUpdated
+        $this.isEntryUpdated = $false
+        return $updated
+    }
+}
+

--- a/module/PowerShellRun/Public/Enable-PSRunEntry.ps1
+++ b/module/PowerShellRun/Public/Enable-PSRunEntry.ps1
@@ -5,12 +5,12 @@ Initializes PSRun entries.
 function Enable-PSRunEntry {
     [CmdletBinding()]
     param (
-        [ValidateSet('All', 'Application', 'Executable', 'Function', 'Utility', 'Favorite')]
+        [ValidateSet('All', 'Application', 'Executable', 'Function', 'Utility', 'Favorite', 'Installer')]
         [String[]]$Category = 'All'
     )
 
     if ($Category -contains 'All') {
-        $Category = 'Application', 'Executable', 'Function', 'Utility', 'Favorite'
+        $Category = 'Application', 'Executable', 'Function', 'Utility', 'Favorite', 'Installer'
     }
     $script:globalStore.EnableEntries($Category)
 }

--- a/src/PowerShellRun/Application/InternalEntry.cs
+++ b/src/PowerShellRun/Application/InternalEntry.cs
@@ -59,6 +59,7 @@ internal class InternalEntry
 
         if (selectorEntry.PreviewAsyncScript is not null)
         {
+            _previewLines = new string[] { "Loading..." };
             _previewLinesLock = new object();
         }
     }

--- a/src/PowerShellRun/Application/InternalEntry.cs
+++ b/src/PowerShellRun/Application/InternalEntry.cs
@@ -16,6 +16,7 @@ internal class InternalEntry
 
     public bool[] NameMatches { get; set; }
     public bool[] DescriptionMatches { get; set; }
+    public bool AlwaysAvailable { get; set; } = false;
     public int Score { get; set; } = 0;
 
     public bool IsMarked { get; set; } = false;
@@ -32,6 +33,10 @@ internal class InternalEntry
         SelectorEntry = selectorEntry;
         Name = FormatWord(selectorEntry.Name);
         NameMatches = new bool[Name.Length];
+        if (selectorEntry.AlwaysAvailable)
+        {
+            AlwaysAvailable = true;
+        }
         if (selectorEntry.Description is not null)
         {
             Description = FormatWord(selectorEntry.Description);

--- a/src/PowerShellRun/Application/Searcher.cs
+++ b/src/PowerShellRun/Application/Searcher.cs
@@ -71,8 +71,9 @@ internal class Searcher
 
             int nameScore = CalculateScore(nameEntry, entry.NameMatches, query);
             int descriptionScore = CalculateScore(descriptionEntry, entry.DescriptionMatches, query);
+            int alwaysScore = entry.AlwaysAvailable ? 1 : 0;
 
-            int score = Math.Max(nameScore, descriptionScore);
+            int score = Math.Max(Math.Max(nameScore, descriptionScore), alwaysScore);
             if (operation == ScoreOperation.And && score == 0)
             {
                 entry.Score = 0;

--- a/src/PowerShellRun/Application/SelectorEntry.cs
+++ b/src/PowerShellRun/Application/SelectorEntry.cs
@@ -15,4 +15,5 @@ public class SelectorEntry
     public int PreviewInitialVerticalScroll { get; set; } = 0;
     public ActionKey[]? ActionKeys = null;
     public ActionKey[]? ActionKeysMultiSelection = null;
+    public bool AlwaysAvailable { get; set; } = false;
 }


### PR DESCRIPTION
The UI for this thing is awesome. I have had an idea for integrating registries which are valid for when there are no results in PSRun for example searching for an app which isn't installed could suggest looking for it in winget/scoop/choco/brew/apt.

There are potentially other situations but my main use-case would be winget.

I've hacked together this proof of concept to see if you think it could work. It's a bit sketchy 😆 I just copied your file registry and hacked it until it worked. I'm also not sure if "Always" is the right term, maybe "Search" registries.

GlobalStore at the moment is hard coded to the built-in registries, so I've just added it to the list to get it to work.

https://github.com/mdgrs-mei/PowerShellRun/assets/13159458/2a6ca1e6-98dc-4242-8e86-83f201989151

