### PR TITLE
Add history search key handler

### DIFF
--- a/module/PowerShellRun/Private/GlobalStore.ps1
+++ b/module/PowerShellRun/Private/GlobalStore.ps1
@@ -18,7 +18,8 @@ class GlobalStore {
     $isReadLineReplaced = $false
     $invokePsRunRequest = $false
     $invokePsRunRequestQuery = ''
-    $psReadLineChord = $null
+    $invokePsRunChord = $null
+    $psReadLineHistoryChord = $null
 
     $firstActionKey = [PowerShellRun.KeyCombination]::new([PowerShellRun.KeyModifier]::None, [PowerShellRun.Key]::None)
     $secondActionKey = [PowerShellRun.KeyCombination]::new([PowerShellRun.KeyModifier]::None, [PowerShellRun.Key]::None)
@@ -38,7 +39,8 @@ class GlobalStore {
         # Wait for async entry initializations
         $this.UpdateEntries()
 
-        $this.RemovePSReadLineKeyHandler()
+        $this.RemoveInvokePsRunChord()
+        $this.RemovePSReadLineHistoryChord()
         $this.RestorePSConsoleHostReadLine()
     }
 
@@ -163,10 +165,11 @@ class GlobalStore {
         $this.invokePsRunRequestQuery = $query
     }
 
-    [void] SetPSReadLineKeyHandler($chord) {
-        $this.RemovePSReadLineKeyHandler()
+    [void] SetInvokePsRunChord($chord) {
+        $this.ReplacePSConsoleHostReadLine()
+        $this.RemoveInvokePsRunChord()
 
-        $this.psReadLineChord = $chord
+        $this.invokePsRunChord = $chord
         Set-PSReadLineKeyHandler -Chord $chord -ScriptBlock {
             $line = $null
             $cursor = $null
@@ -178,10 +181,26 @@ class GlobalStore {
         }
     }
 
-    [void] RemovePSReadLineKeyHandler() {
-        if ($this.psReadLineChord) {
-            Remove-PSReadLineKeyHandler -Chord $this.psReadLineChord
-            $this.psReadLineChord = $null
+    [void] RemoveInvokePsRunChord() {
+        if ($this.invokePsRunChord) {
+            Remove-PSReadLineKeyHandler -Chord $this.invokePsRunChord
+            $this.invokePsRunChord = $null
+        }
+    }
+
+    [void] SetPSReadLineHistoryChord($chord) {
+        $this.RemovePSReadLineHistoryChord()
+
+        $this.psReadLineHistoryChord = $chord
+        Set-PSReadLineKeyHandler -Chord $chord -ScriptBlock {
+            SearchPSReadLineHistory
+        }
+    }
+
+    [void] RemovePSReadLineHistoryChord() {
+        if ($this.psReadLineHistoryChord) {
+            Remove-PSReadLineKeyHandler -Chord $this.psReadLineHistoryChord
+            $this.psReadLineHistoryChord = $null
         }
     }
 

--- a/module/PowerShellRun/Private/PSReadLineHistory.ps1
+++ b/module/PowerShellRun/Private/PSReadLineHistory.ps1
@@ -1,0 +1,50 @@
+function SearchPSReadLineHistory() {
+    [Microsoft.PowerShell.PSConsoleReadLine]::ClearScreen()
+
+    $cursorPos = $null
+    $initialQuery = $null
+    [Microsoft.PowerShell.PSConsoleReadLine]::GetBufferState([ref]$initialQuery, [ref]$cursorPos)
+
+    $historyItems = [Microsoft.PowerShell.PSConsoleReadLine]::GetHistoryItems()
+    [Array]::Reverse($historyItems)
+
+    $historySet = [System.Collections.Generic.Hashset[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    foreach ($item in $historyItems) {
+        $historySet.Add($item.CommandLine) | Out-Null
+    }
+
+    $context = [PowerShellRun.SelectorContext]::new()
+    $context.Query = $initialQuery
+
+    $actionKeys = @(
+        [PowerShellRun.ActionKey]::new($script:globalStore.firstActionKey, 'Execute')
+        [PowerShellRun.ActionKey]::new($script:globalStore.secondActionKey, 'Insert')
+        [PowerShellRun.ActionKey]::new($script:globalStore.copyActionKey, 'Copy command to Clipboard')
+    )
+
+    $result = $historySet | ForEach-Object {
+        $entry = [PowerShellRun.SelectorEntry]::new()
+        $entry.Name = $_
+        $entry.Preview = $_
+        $entry.ActionKeys = $actionKeys
+        $entry
+    } | Invoke-PSRunSelectorCustom -Context $context
+
+    $command = $result.FocusedEntry.Name
+    if (-not $command) {
+        [Microsoft.PowerShell.PSConsoleReadLine]::SetCursorPosition($cursorPos)
+        return
+    }
+
+    if ($result.KeyCombination -eq $script:globalStore.firstActionKey) {
+        [Microsoft.PowerShell.PSConsoleReadLine]::RevertLine()
+        [Microsoft.PowerShell.PSConsoleReadLine]::Insert($command)
+        [Microsoft.PowerShell.PSConsoleReadLine]::AcceptLine()
+    } elseif ($result.KeyCombination -eq $script:globalStore.secondActionKey) {
+        [Microsoft.PowerShell.PSConsoleReadLine]::RevertLine()
+        [Microsoft.PowerShell.PSConsoleReadLine]::Insert($command)
+    } elseif ($result.KeyCombination -eq $script:globalStore.copyActionKey) {
+        [Microsoft.PowerShell.PSConsoleReadLine]::RevertLine()
+        $command | Set-Clipboard
+    }
+}

--- a/module/PowerShellRun/Private/PSReadLineHistory.ps1
+++ b/module/PowerShellRun/Private/PSReadLineHistory.ps1
@@ -22,9 +22,14 @@ function SearchPSReadLineHistory() {
         [PowerShellRun.ActionKey]::new($script:globalStore.copyActionKey, 'Copy command to Clipboard')
     )
 
+    $maxNameLength = 128
     $result = $historySet | ForEach-Object {
         $entry = [PowerShellRun.SelectorEntry]::new()
-        $entry.Name = $_
+        $entry.Name = if ($_.Length -gt $maxNameLength) {
+            $_.Substring(0, $maxNameLength)
+        } else {
+            $_
+        }
         $entry.Preview = $_
         $entry.ActionKeys = $actionKeys
         $entry

--- a/module/PowerShellRun/Public/Set-PSRunPSReadLineKeyHandler.ps1
+++ b/module/PowerShellRun/Public/Set-PSRunPSReadLineKeyHandler.ps1
@@ -2,12 +2,21 @@ function Set-PSRunPSReadLineKeyHandler {
     [CmdletBinding()]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '')]
     param (
-        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
-        [String[]]$Chord
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [Alias('Chord')]
+        [String[]]$InvokePsRunChord,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [String[]]$PSReadLineHistoryChord
     )
 
     process {
-        $script:globalStore.ReplacePSConsoleHostReadLine()
-        $script:globalStore.SetPSReadLineKeyHandler($Chord)
+        if ($InvokePsRunChord) {
+            $script:globalStore.SetInvokePsRunChord($InvokePsRunChord)
+        }
+
+        if ($PSReadLineHistoryChord) {
+            $script:globalStore.SetPSReadLineHistoryChord($PSReadLineHistoryChord)
+        }
     }
 }

--- a/tests/Public/Set-PSRunPSReadLineKeyHandler.Tests.ps1
+++ b/tests/Public/Set-PSRunPSReadLineKeyHandler.Tests.ps1
@@ -3,11 +3,19 @@
         Import-Module $PSScriptRoot/../../module/PowerShellRun -Force
     }
 
-    It 'should set the option as default' {
-        Set-PSRunPSReadLineKeyHandler -Chord 'Ctrl+j'
+    It 'should store key handler for InvokePSRun' {
+        Set-PSRunPSReadLineKeyHandler -InvokePsRunChord 'Ctrl+j'
 
         InModuleScope 'PowerShellRun' {
-            $script:globalStore.psReadLineChord | Should -Be 'Ctrl+j'
+            $script:globalStore.invokePsRunChord | Should -Be 'Ctrl+j'
+        }
+    }
+
+    It 'should store key handler for PSReadLineHistory' {
+        Set-PSRunPSReadLineKeyHandler -PSReadLineHistoryChord 'Ctrl+f'
+
+        InModuleScope 'PowerShellRun' {
+            $script:globalStore.psReadLineHistoryChord | Should -Be 'Ctrl+f'
         }
     }
 

--- a/tests/RestartableSession.ps1
+++ b/tests/RestartableSession.ps1
@@ -9,6 +9,7 @@ Enter-RSSession -OnStart {
     & $build Debug
     Import-Module "$root/module/PowerShellRun"
     Enable-PSRunEntry -Category All
+    Set-PSRunPSReadLineKeyHandler -InvokePSRunChord 'Ctrl+Spacebar' -PSReadLineHistoryChord 'Ctrl+r'
 
     function Restart {
         Restart-RSSession


### PR DESCRIPTION
Fixes #33.

The key handler can be added by `Set-PSRunPSReadLineKeyHandler` function.

```powershell
Set-PSRunPSReadLineKeyHandler -InvokePSRunChord 'Ctrl+Spacebar' -PSReadLineHistoryChord 'Ctrl+r'
``` 

![image](https://github.com/mdgrs-mei/PowerShellRun/assets/81177095/af6e5c2d-d583-4151-876f-6b21c37aadb9)
