### PR TITLE
Add escape sequence layering

### DIFF
--- a/src/PowerShellRun/UI/Canvas.cs
+++ b/src/PowerShellRun/UI/Canvas.cs
@@ -161,8 +161,7 @@ internal sealed class Canvas : Singleton<Canvas>
 
         var cell = _cells[index];
         cell.SetCharacter(character, foregroundColor, backgroundColor, fontStyle, optionFlags);
-        cell.HeadEscapeSequence = escapeSequence;
-        cell.TailEscapeSequence = null;
+        cell.EscapeSequence = escapeSequence;
     }
 
     public void SetCell(
@@ -244,9 +243,9 @@ internal sealed class Canvas : Singleton<Canvas>
                 {
                     escapeSequence = null;
                 }
-                if (cell.HeadEscapeSequence is not null)
+                if (cell.EscapeSequence is not null)
                 {
-                    escapeSequence = cell.HeadEscapeSequence;
+                    escapeSequence = cell.EscapeSequence;
                     shouldSetEscapeSequence = true;
                     forceResetFont = true;
                 }

--- a/src/PowerShellRun/UI/Canvas.cs
+++ b/src/PowerShellRun/UI/Canvas.cs
@@ -234,7 +234,7 @@ internal sealed class Canvas : Singleton<Canvas>
                 bool shouldSetBackgroundColor = false;
                 bool shouldSetStyle = false;
 
-                bool forceResetFont = cell.OptionFlags.HasFlag(CanvasCell.Option.ForceResetColor);
+                bool forceResetFont = cell.OptionFlags.HasFlag(CanvasCell.Option.ForceResetFont);
                 forceResetFont = forceResetFont || forceResetFontNext;
                 forceResetFontNext = cell.OptionFlags.HasFlag(CanvasCell.Option.ForceResetFontNext);
                 bool escapeSequenceLowPriority = cell.OptionFlags.HasFlag(CanvasCell.Option.EscapeSequenceLowPriority);

--- a/src/PowerShellRun/UI/CanvasCell.cs
+++ b/src/PowerShellRun/UI/CanvasCell.cs
@@ -10,6 +10,8 @@ internal class CanvasCell
     {
         None = 0,
         ForceResetColor = 1 << 0,
+        ForceResetFontNext = 1 << 1,
+        EscapeSequenceLowPriority = 1 << 2,
     }
 
     public char Character { get; set; }

--- a/src/PowerShellRun/UI/CanvasCell.cs
+++ b/src/PowerShellRun/UI/CanvasCell.cs
@@ -9,7 +9,7 @@ internal class CanvasCell
     public enum Option
     {
         None = 0,
-        ForceResetColor = 1 << 0,
+        ForceResetFont = 1 << 0,
         ForceResetFontNext = 1 << 1,
         EscapeSequenceLowPriority = 1 << 2,
     }

--- a/src/PowerShellRun/UI/CanvasCell.cs
+++ b/src/PowerShellRun/UI/CanvasCell.cs
@@ -15,8 +15,7 @@ internal class CanvasCell
     }
 
     public char Character { get; set; }
-    public string? HeadEscapeSequence { get; set; }
-    public string? TailEscapeSequence { get; set; }
+    public string? EscapeSequence { get; set; }
     public FontColor? ForegroundColor { get; set; }
     public FontColor? BackgroundColor { get; set; }
     public FontStyle FontStyle { get; set; }
@@ -30,8 +29,7 @@ internal class CanvasCell
     public void Clear()
     {
         Character = ' ';
-        HeadEscapeSequence = null;
-        TailEscapeSequence = null;
+        EscapeSequence = null;
         ForegroundColor = null;
         BackgroundColor = null;
         FontStyle = FontStyle.Default;
@@ -41,8 +39,7 @@ internal class CanvasCell
     public void CopyTo(CanvasCell cell)
     {
         cell.Character = Character;
-        cell.HeadEscapeSequence = HeadEscapeSequence;
-        cell.TailEscapeSequence = TailEscapeSequence;
+        cell.EscapeSequence = EscapeSequence;
         cell.ForegroundColor = ForegroundColor;
         cell.BackgroundColor = BackgroundColor;
         cell.FontStyle = FontStyle;

--- a/src/PowerShellRun/UI/LayoutItem.cs
+++ b/src/PowerShellRun/UI/LayoutItem.cs
@@ -137,7 +137,7 @@ internal abstract class LayoutItem
                 {
                     character = BorderSymbol.BottomLeft;
                 }
-                canvas.SetCell(X, Y + i, character, BorderForegroundColor, BorderBackgroundColor, FontStyle.Default, null, CanvasCell.Option.ForceResetColor);
+                canvas.SetCell(X, Y + i, character, BorderForegroundColor, BorderBackgroundColor, FontStyle.Default, null, CanvasCell.Option.ForceResetFont);
             }
         }
         if (BorderFlags.HasFlag(BorderFlag.Right))
@@ -154,14 +154,14 @@ internal abstract class LayoutItem
                 {
                     character = BorderSymbol.BottomRight;
                 }
-                canvas.SetCell(rightEnd, Y + i, character, BorderForegroundColor, BorderBackgroundColor, FontStyle.Default, null, CanvasCell.Option.ForceResetColor);
+                canvas.SetCell(rightEnd, Y + i, character, BorderForegroundColor, BorderBackgroundColor, FontStyle.Default, null, CanvasCell.Option.ForceResetFont);
             }
         }
         if (BorderFlags.HasFlag(BorderFlag.Top))
         {
             for (int i = 0; i < Width; ++i)
             {
-                var option = i == 0 ? CanvasCell.Option.ForceResetColor : CanvasCell.Option.None;
+                var option = i == 0 ? CanvasCell.Option.ForceResetFont : CanvasCell.Option.None;
                 if (i == 0 && BorderFlags.HasFlag(BorderFlag.Left))
                     continue;
                 if (i == Width - 1 && BorderFlags.HasFlag(BorderFlag.Right))
@@ -173,7 +173,7 @@ internal abstract class LayoutItem
         {
             for (int i = 0; i < Width; ++i)
             {
-                var option = i == 0 ? CanvasCell.Option.ForceResetColor : CanvasCell.Option.None;
+                var option = i == 0 ? CanvasCell.Option.ForceResetFont : CanvasCell.Option.None;
                 if (i == 0 && BorderFlags.HasFlag(BorderFlag.Left))
                     continue;
                 if (i == Width - 1 && BorderFlags.HasFlag(BorderFlag.Right))

--- a/src/PowerShellRun/UI/TextBox.cs
+++ b/src/PowerShellRun/UI/TextBox.cs
@@ -135,7 +135,7 @@ internal class TextBox : LayoutItem
                     fontStyle,
                     option);
 
-                cell.HeadEscapeSequence = escape.EscapeSequence;
+                cell.EscapeSequence = escape.EscapeSequence;
                 Cells.Add(cell);
 
                 ++cellIndex;

--- a/src/PowerShellRun/UI/TextBox.cs
+++ b/src/PowerShellRun/UI/TextBox.cs
@@ -120,7 +120,7 @@ internal class TextBox : LayoutItem
                 CanvasCell.Option option = CanvasCell.Option.None;
                 if (escape.ShouldReset)
                 {
-                    option |= CanvasCell.Option.ForceResetColor;
+                    option |= CanvasCell.Option.ForceResetFont;
                 }
                 if (isHighlight)
                 {
@@ -672,7 +672,7 @@ internal class TextBox : LayoutItem
                 canvas.SetCellOption(
                     leftEnd,
                     y,
-                    CanvasCell.Option.ForceResetColor);
+                    CanvasCell.Option.ForceResetFont);
                 ++y;
             }
         }
@@ -727,7 +727,7 @@ internal class TextBox : LayoutItem
                         ScrollBarBackgroundColor,
                         FontStyle.Default,
                         null,
-                        CanvasCell.Option.ForceResetColor);
+                        CanvasCell.Option.ForceResetFont);
                 }
             }
         }


### PR DESCRIPTION
This PR adds font setting layering between escape sequences and PowerShellRun's font settings.

- The reset escape sequence `\x1b[0m` resets the color and style to PowerShellRun's settings, not terminal's default.
- The color and style of match highlights have higher priority than escape sequences.

```powershell
$option = [PowerShellRun.SelectorOption]::new()
$option.Theme.DescriptionForegroundColor = [PowerShellRun.FontColor]::Blue
$option.Theme.PreviewBoxBackgroundColor = [PowerShellRun.FontColor]::Green

'1.', '2.' | Invoke-PSRunSelector -Expression { @{
        Name = $_ + 'aaa' + $PSStyle.Foreground.Yellow + 'ttt' + $PSStyle.Reset + 'aaa'
        Description = $_ + 'aaa' + $PSStyle.Foreground.Red + 'ttt' + $PSStyle.Background.Blue + 'aaa' + $PSStyle.Reset
        Preview = $_ + 'aaa' + $PSStyle.Reset + $PSStyle.Background.Magenta + 'ttt' + $PSStyle.Reset + 'aaa'
    } } -Option $option
```

- Before

![image](https://github.com/mdgrs-mei/PowerShellRun/assets/81177095/3b2dab33-4265-48a7-b486-587789c4b714)

- After

![image](https://github.com/mdgrs-mei/PowerShellRun/assets/81177095/29bbc21b-a3cc-4cce-90dd-53612a62b02e)

