### PR TITLE
Add searchable character pattern for Name and Description

### DIFF
--- a/src/PowerShellRun/Application/Searcher.cs
+++ b/src/PowerShellRun/Application/Searcher.cs
@@ -69,8 +69,19 @@ internal class Searcher
             string nameEntry = useLowerCase ? entry.SearchNameLowerCase : entry.SearchName;
             string descriptionEntry = useLowerCase ? entry.SearchDescriptionLowerCase : entry.SearchDescription;
 
-            int nameScore = CalculateScore(nameEntry, entry.NameMatches, query);
-            int descriptionScore = CalculateScore(descriptionEntry, entry.DescriptionMatches, query);
+            int nameScore = CalculateScore(
+                nameEntry,
+                entry.SearchNameStartIndex,
+                entry.SearchNameLength,
+                entry.NameMatches,
+                query);
+
+            int descriptionScore = CalculateScore(
+                descriptionEntry,
+                entry.SearchDescriptionStartIndex,
+                entry.SearchDescriptionLength,
+                entry.DescriptionMatches,
+                query);
 
             int score = Math.Max(nameScore, descriptionScore);
             if (operation == ScoreOperation.And && score == 0)
@@ -84,7 +95,7 @@ internal class Searcher
         }
     }
 
-    private int CalculateScore(string searchEntry, bool[] matches, string query)
+    private int CalculateScore(string searchEntry, int startIndex, int length, bool[] matches, string query)
     {
         int score = 0;
         if (string.IsNullOrEmpty(searchEntry) || string.IsNullOrEmpty(query))
@@ -109,14 +120,14 @@ internal class Searcher
         if (score > 0)
         {
             // Short name entires get higher score
-            score += Math.Max(50 - searchEntry.Length, 1);
+            score += Math.Max(50 - length, 1);
         }
 
         {
             if (matchIndexes.MatchStartIndex is int matchStartIndex)
             {
                 // First character match gets higher score
-                if (matchStartIndex == 0)
+                if (matchStartIndex == startIndex)
                 {
                     score += 10;
                 }

--- a/src/PowerShellRun/Application/SelectorEntry.cs
+++ b/src/PowerShellRun/Application/SelectorEntry.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Management.Automation;
+using System.Text.RegularExpressions;
 
 namespace PowerShellRun;
 
@@ -8,7 +9,9 @@ public class SelectorEntry
     public object? UserData { get; set; } = null;
     public string? Icon { get; set; } = null;
     public string Name { get; set; } = "";
+    public Regex? NameSearchablePattern { get; set; } = null;
     public string? Description { get; set; } = null;
+    public Regex? DescriptionSearchablePattern { get; set; } = null;
     public string[]? Preview { get; set; } = null;
     public ScriptBlock? PreviewAsyncScript { get; set; } = null;
     public object[]? PreviewAsyncScriptArgumentList { get; set; } = null;

--- a/tests/Public/Invoke-PSRunSelector.Tests.ps1
+++ b/tests/Public/Invoke-PSRunSelector.Tests.ps1
@@ -47,6 +47,12 @@
         $match | Should -Be 'acb'
     }
 
+    It 'should prioritize shorter entry' {
+        $context.Query = 'ab'
+        $match = 'abc', 'abcd', 'ab' | Invoke-PSRunSelector -Option $option -Context $context
+        $match | Should -Be 'ab'
+    }
+
     It 'should prioritize the first character match' {
         $context.Query = 'ab'
         $match = 'cab', 'abc' | Invoke-PSRunSelector -Option $option -Context $context
@@ -63,6 +69,18 @@
         $context.Query = '0m'
         $match = $PSStyle.Foreground.Red + 'abc' + $PSStyle.Reset | Invoke-PSRunSelector -Option $option -Context $context
         $match | Should -BeNullOrEmpty
+    }
+
+    It 'should prioritize shorter entry even with escape sequences' {
+        $context.Query = 'ab'
+        $match = 'abc', 'abcd', ($PSStyle.Foreground.Red + 'ab' + $PSStyle.Reset) | Invoke-PSRunSelector -Option $option -Context $context
+        $match | Should -Be ($PSStyle.Foreground.Red + 'ab' + $PSStyle.Reset)
+    }
+
+    It 'should prioritize the first character match even with escape sequences' {
+        $context.Query = 'ab'
+        $match = 'cab', ($PSStyle.Foreground.Red + 'abc' + $PSStyle.Reset) | Invoke-PSRunSelector -Option $option -Context $context
+        $match | Should -Be ($PSStyle.Foreground.Red + 'abc' + $PSStyle.Reset)
     }
 
     It 'should not throw an exception with multi selection' {

--- a/tests/Public/Invoke-PSRunSelectorCustom.Tests.ps1
+++ b/tests/Public/Invoke-PSRunSelectorCustom.Tests.ps1
@@ -44,6 +44,31 @@
         $result.FocusedEntry.UserData | Should -Be $items[0]
     }
 
+    It 'should process searchable pattern for Name' {
+        $context.Query = 'abc'
+        $result = 'abc def', 'def abc' | ForEach-Object {
+            $entry = [PowerShellRun.SelectorEntry]::new()
+            $entry.UserData = $_
+            $entry.Name = $_
+            $entry.NameSearchablePattern = '(?<=^\S*\s).*'
+            $entry
+        } | Invoke-PSRunSelectorCustom -Option $option -Context $context
+        $result.FocusedEntry.UserData | Should -Be 'def abc'
+    }
+
+    It 'should process searchable pattern for Name' {
+        $context.Query = 'abc'
+        $result = 'abc def', 'def abc' | ForEach-Object {
+            $entry = [PowerShellRun.SelectorEntry]::new()
+            $entry.UserData = $_
+            $entry.Name = 'name'
+            $entry.Description = $_
+            $entry.DescriptionSearchablePattern = '(?<=^\S*\s).*'
+            $entry
+        } | Invoke-PSRunSelectorCustom -Option $option -Context $context
+        $result.FocusedEntry.UserData | Should -Be 'def abc'
+    }
+
     AfterEach {
         Remove-Module PowerShellRun -Force
     }


### PR DESCRIPTION
This PR adds `NameSearchablePattern` and `DescriptionSearchablePattern` properties to `SelectorEntry`. If specified, Only characters that are matched by the regex pattern will be searchable.

## Example1: The second word split by space is searchable

```powershell
$pattern = [Regex]::new('(?<=^\S*\s).*?(?=\s|$)')
'aaa bbb aaa', 'bbb aaa bbb' | ForEach-Object {
    $entry = [PowerShellRun.SelectorEntry]::new()
    $entry.Name = $_
    $entry.NameSearchablePattern = $pattern
    $entry
} | Invoke-PSRunSelectorCustom
```
![image](https://github.com/mdgrs-mei/PowerShellRun/assets/81177095/d6c87ac4-685f-44f9-9644-dc0830289aa3)

## Example2: All words inside [] are searchable

```powershell
$pattern = [Regex]::new('(?<=\[).*?(?=\])')
'aaa [bbb] [ccc]', '[aaa] bbb ccc' | ForEach-Object {
    $entry = [PowerShellRun.SelectorEntry]::new()
    $entry.Name = $_
    $entry.NameSearchablePattern = $pattern
    $entry
} | Invoke-PSRunSelectorCustom
```
![image](https://github.com/mdgrs-mei/PowerShellRun/assets/81177095/ccedbabd-318d-463f-8595-c6ad32deee30)

## Example3: Method or Property names are searchable

```powershell
$pattern = [Regex]::new('(?<=^\S*\s).*?(?=\s|\(|{|$)')
$members = [Regex] | Get-Member
$members | ForEach-Object {
    $entry = [PowerShellRun.SelectorEntry]::new()
    $entry.Name = $_.Definition
    $entry.NameSearchablePattern = $pattern
    $entry
} | Invoke-PSRunSelectorCustom
```

![image](https://github.com/mdgrs-mei/PowerShellRun/assets/81177095/ad0b7b99-207a-4b45-9f13-3b7aac53f677)

