### PR TITLE
Script Block and Script File entries

### DIFF
--- a/module/PowerShellRun/PowerShellRun.psd1
+++ b/module/PowerShellRun/PowerShellRun.psd1
@@ -64,6 +64,8 @@
     FunctionsToExport = @(
         'Add-PSRunFavoriteFile'
         'Add-PSRunFavoriteFolder'
+        'Add-PSRunScriptBlock'
+        'Add-PSRunScriptFile'
         'Enable-PSRunEntry'
         'Get-PSRunDefaultSelectorOption'
         'Invoke-PSRun'

--- a/module/PowerShellRun/Private/FileSystemRegistry.ps1
+++ b/module/PowerShellRun/Private/FileSystemRegistry.ps1
@@ -7,15 +7,9 @@ class FileSystemRegistry : EntryRegistry {
     $isFileManagerEnabled = $false
     $isEntryUpdated = $false
 
-    [ScriptBlock]$defaultEditorScript
     $fileManagerArguments
 
     FileSystemRegistry() {
-        $this.defaultEditorScript = {
-            param ($path)
-            Invoke-Item $path
-        }
-
         $this.fileManagerArguments = @{
             This = $this
             FolderActionKeys = @(
@@ -70,10 +64,6 @@ class FileSystemRegistry : EntryRegistry {
         if ($this.isFileManagerEnabled) {
             $this.RegisterFileManagerEntry()
         }
-    }
-
-    [void] SetDefaultEditorScript([ScriptBlock]$scriptBlock) {
-        $this.defaultEditorScript = $scriptBlock
     }
 
     [void] RegisterFileManagerEntry() {
@@ -151,7 +141,7 @@ class FileSystemRegistry : EntryRegistry {
             if ($result.KeyCombination -eq $script:globalStore.firstActionKey) {
                 & $script:globalStore.invokeFile $path
             } elseif ($result.KeyCombination -eq $script:globalStore.secondActionKey) {
-                & $arguments.This.defaultEditorScript $path
+                & $script:globalStore.defaultEditorScript $path
             } elseif ($result.KeyCombination -eq $script:globalStore.thirdActionKey) {
                 $arguments.This.OpenContainingFolder($path)
             } elseif ($result.KeyCombination -eq $script:globalStore.copyActionKey) {
@@ -257,7 +247,7 @@ class FileSystemRegistry : EntryRegistry {
                 if ($item.PSIsContainer) {
                     Set-Location $item.FullName
                 } else {
-                    & $arguments.This.defaultEditorScript $item.FullName
+                    & $script:globalStore.defaultEditorScript $item.FullName
                 }
                 break
             } elseif ($result.KeyCombination -eq $script:globalStore.thirdActionKey) {

--- a/module/PowerShellRun/Private/FileSystemRegistry.ps1
+++ b/module/PowerShellRun/Private/FileSystemRegistry.ps1
@@ -136,7 +136,7 @@ class FileSystemRegistry : EntryRegistry {
     [void] AddFavoriteFile($filePath, $icon, $name, $description, $preview) {
         $callback = {
             $result = $args[0].Result
-            $arguments, $path = $args[0].ArgumentList
+            $path = $args[0].ArgumentList
 
             if ($result.KeyCombination -eq $script:globalStore.firstActionKey) {
                 & $script:globalStore.invokeFile $path
@@ -163,7 +163,7 @@ class FileSystemRegistry : EntryRegistry {
 
         $entry.UserData = @{
             ScriptBlock = $callback
-            ArgumentList = $this.fileManagerArguments, $filePath
+            ArgumentList = $filePath
         }
 
         $this.favoritesEntries.Add($entry)
@@ -186,7 +186,7 @@ class FileSystemRegistry : EntryRegistry {
 
             $entries = [System.Collections.Generic.List[PowerShellRun.SelectorEntry]]::new()
             $addEntry = {
-                param($item, $name, $icon)
+                param($arguments, $item, $name, $icon)
                 $entry = [PowerShellRun.SelectorEntry]::new()
                 $entry.UserData = $item
                 $entry.Name = $name
@@ -204,12 +204,12 @@ class FileSystemRegistry : EntryRegistry {
             }
 
             Get-ChildItem -Path $currentDir.path | ForEach-Object {
-                $addEntry.Invoke($_, $_.Name)
+                $addEntry.Invoke($arguments, $_, $_.Name)
             }
 
             $parentItem = (Get-Item $currentDir.path).Parent
             if ($parentItem) {
-                $addEntry.Invoke((Get-Item $parentItem.FullName), '../', '🔼')
+                $addEntry.Invoke($arguments, (Get-Item $parentItem.FullName), '../', '🔼')
             }
 
             $result = Invoke-PSRunSelectorCustom -Entry $entries -Option $option

--- a/module/PowerShellRun/Private/FileSystemRegistry.ps1
+++ b/module/PowerShellRun/Private/FileSystemRegistry.ps1
@@ -143,7 +143,7 @@ class FileSystemRegistry : EntryRegistry {
             } elseif ($result.KeyCombination -eq $script:globalStore.secondActionKey) {
                 & $script:globalStore.defaultEditorScript $path
             } elseif ($result.KeyCombination -eq $script:globalStore.thirdActionKey) {
-                $arguments.This.OpenContainingFolder($path)
+                $script:globalStore.OpenContainingFolder($path)
             } elseif ($result.KeyCombination -eq $script:globalStore.copyActionKey) {
                 $path | Set-Clipboard
             }
@@ -254,7 +254,7 @@ class FileSystemRegistry : EntryRegistry {
                 if ($item.PSIsContainer) {
                     Invoke-Item $item.FullName
                 } else {
-                    $arguments.This.OpenContainingFolder($item.FullName)
+                    $script:globalStore.OpenContainingFolder($item.FullName)
                 }
                 break
             } elseif ($result.KeyCombination -eq $script:globalStore.copyActionKey) {
@@ -263,15 +263,6 @@ class FileSystemRegistry : EntryRegistry {
             } else {
                 break
             }
-        }
-    }
-
-    [void] OpenContainingFolder($path) {
-        if ($script:isWindows) {
-            & explorer.exe (('/select,{0}' -f $path).Split())
-        } else {
-            $parentDir = ([System.IO.Directory]::GetParent($path)).FullName
-            Invoke-Item $parentDir
         }
     }
 

--- a/module/PowerShellRun/Private/GlobalStore.ps1
+++ b/module/PowerShellRun/Private/GlobalStore.ps1
@@ -7,6 +7,7 @@ class GlobalStore {
 
     $registryClassNames = @(
         'FunctionRegistry'
+        'ScriptRegistry'
         'FileSystemRegistry'
         'WinGetRegistry'
         'ApplicationRegistry'

--- a/module/PowerShellRun/Private/GlobalStore.ps1
+++ b/module/PowerShellRun/Private/GlobalStore.ps1
@@ -27,8 +27,15 @@ class GlobalStore {
     $thirdActionKey = [PowerShellRun.KeyCombination]::new([PowerShellRun.KeyModifier]::None, [PowerShellRun.Key]::None)
     $copyActionKey = [PowerShellRun.KeyCombination]::new([PowerShellRun.KeyModifier]::None, [PowerShellRun.Key]::None)
 
+    [ScriptBlock]$defaultEditorScript
+
     [void] Initialize() {
         $this.InitializeActionKeys()
+
+        $this.defaultEditorScript = {
+            param ($path)
+            Invoke-Item $path
+        }
 
         foreach ($className in $this.registryClassNames) {
             $registry = New-Object $className
@@ -203,6 +210,10 @@ class GlobalStore {
             Remove-PSReadLineKeyHandler -Chord $this.psReadLineHistoryChord
             $this.psReadLineHistoryChord = $null
         }
+    }
+
+    [void] SetDefaultEditorScript([ScriptBlock]$scriptBlock) {
+        $this.defaultEditorScript = $scriptBlock
     }
 
     # Class methods cannot pass through the output of invoked command line apps in realtime so we use ScriptBlock.

--- a/module/PowerShellRun/Private/GlobalStore.ps1
+++ b/module/PowerShellRun/Private/GlobalStore.ps1
@@ -216,6 +216,15 @@ class GlobalStore {
         $this.defaultEditorScript = $scriptBlock
     }
 
+    [void] OpenContainingFolder($path) {
+        if ($script:isWindows) {
+            & explorer.exe (('/select,{0}' -f $path).Split())
+        } else {
+            $parentDir = ([System.IO.Directory]::GetParent($path)).FullName
+            Invoke-Item $parentDir
+        }
+    }
+
     # Class methods cannot pass through the output of invoked command line apps in realtime so we use ScriptBlock.
     $invokeFile = {
         param($path)

--- a/module/PowerShellRun/Private/ScriptRegistry.ps1
+++ b/module/PowerShellRun/Private/ScriptRegistry.ps1
@@ -69,7 +69,7 @@ class ScriptRegistry : EntryRegistry {
 
         $this.scriptFilePreviewScript = {
             param ($path)
-            Get-Item $path | Out-String
+            Get-Content $path
         }
     }
 

--- a/module/PowerShellRun/Private/ScriptRegistry.ps1
+++ b/module/PowerShellRun/Private/ScriptRegistry.ps1
@@ -59,7 +59,9 @@ class ScriptRegistry : EntryRegistry {
             if ($result.KeyCombination -eq $script:globalStore.firstActionKey) {
                 & $filePath
             } elseif ($result.KeyCombination -eq $script:globalStore.secondActionKey) {
+                & $script:globalStore.defaultEditorScript $filePath
             } elseif ($result.KeyCombination -eq $script:globalStore.thirdActionKey) {
+                $script:globalStore.OpenContainingFolder($filePath)
             } elseif ($result.KeyCombination -eq $script:globalStore.copyActionKey) {
                 $filePath | Set-Clipboard
             }

--- a/module/PowerShellRun/Private/ScriptRegistry.ps1
+++ b/module/PowerShellRun/Private/ScriptRegistry.ps1
@@ -1,0 +1,123 @@
+using module ./_EntryRegistry.psm1
+class ScriptRegistry : EntryRegistry {
+    $entries = [System.Collections.Generic.List[PowerShellRun.SelectorEntry]]::new()
+    $isEntryUpdated = $false
+    $isEnabled = $false
+
+    $scriptBlockActionKeys
+    $scriptBlockCallback
+    $scriptFileActionKeys
+    $scriptFileCallback
+    $scriptFilePreviewScript
+
+    [System.Collections.Generic.List[PowerShellRun.SelectorEntry]] GetEntries() {
+        if ($this.isEnabled) {
+            return $this.entries
+        }
+        return $null
+    }
+
+    [void] EnableEntries([String[]]$categories) {
+        $enabled = $categories -contains 'Script'
+        if ($this.isEnabled -ne $enabled) {
+            $this.isEntryUpdated = $true
+        }
+        $this.isEnabled = $enabled
+    }
+
+    ScriptRegistry() {
+        $this.scriptBlockActionKeys = @(
+            [PowerShellRun.ActionKey]::new($script:globalStore.firstActionKey, 'Invoke script')
+            [PowerShellRun.ActionKey]::new($script:globalStore.secondActionKey, 'Get definition')
+            [PowerShellRun.ActionKey]::new($script:globalStore.copyActionKey, 'Copy definition to Clipboard')
+        )
+
+        $this.scriptBlockCallback = {
+            $result = $args[0].Result
+            $scriptBlock = $args[0].ArgumentList
+
+            if ($result.KeyCombination -eq $script:globalStore.firstActionKey) {
+                & $scriptBlock
+            } elseif ($result.KeyCombination -eq $script:globalStore.secondActionKey) {
+                $scriptBlock.ToString()
+            } elseif ($result.KeyCombination -eq $script:globalStore.copyActionKey) {
+                $scriptBlock.ToString() | Set-Clipboard
+            }
+        }
+
+        $this.scriptFileActionKeys = @(
+            [PowerShellRun.ActionKey]::new($script:globalStore.firstActionKey, 'Invoke script')
+            [PowerShellRun.ActionKey]::new($script:globalStore.secondActionKey, 'Edit with default editor')
+            [PowerShellRun.ActionKey]::new($script:globalStore.thirdActionKey, 'Open containing folder')
+            [PowerShellRun.ActionKey]::new($script:globalStore.copyActionKey, 'Copy path to Clipboard')
+        )
+
+        $this.scriptFileCallback = {
+            $result = $args[0].Result
+            $filePath = $args[0].ArgumentList
+
+            if ($result.KeyCombination -eq $script:globalStore.firstActionKey) {
+                & $filePath
+            } elseif ($result.KeyCombination -eq $script:globalStore.secondActionKey) {
+            } elseif ($result.KeyCombination -eq $script:globalStore.thirdActionKey) {
+            } elseif ($result.KeyCombination -eq $script:globalStore.copyActionKey) {
+                $filePath | Set-Clipboard
+            }
+        }
+
+        $this.scriptFilePreviewScript = {
+            param ($path)
+            Get-Item $path | Out-String
+        }
+    }
+
+    [void] AddScriptBlock($scriptBlock, $icon, $name, $description, $preview) {
+        $entry = [PowerShellRun.SelectorEntry]::new()
+        $entry.Icon = if ($icon) { $icon } else { '{}' }
+        $entry.Name = $name
+        $entry.Description = $description
+        if ($preview) {
+            $entry.Preview = $preview
+        } else {
+            $entry.Preview = '{' + $scriptBlock.ToString() + '}'
+        }
+        $entry.ActionKeys = $this.scriptBlockActionKeys
+
+        $entry.UserData = @{
+            ScriptBlock = $this.scriptBlockCallback
+            ArgumentList = $scriptBlock
+        }
+
+        $this.entries.Add($entry)
+        $this.isEntryUpdated = $true
+    }
+
+    [void] AddScriptFile($filePath, $icon, $name, $description, $preview) {
+        $entry = [PowerShellRun.SelectorEntry]::new()
+        $entry.Icon = if ($icon) { $icon } else { '📘' }
+        $entry.Name = if ($name) { $name } else { Split-Path $filePath -Leaf }
+        $entry.Description = if ($description) { $description } else { $filePath }
+        if ($preview) {
+            $entry.Preview = $preview
+        } else {
+            $entry.PreviewAsyncScript = $this.scriptFilePreviewScript
+            $entry.PreviewAsyncScriptArgumentList = $filePath
+        }
+        $entry.ActionKeys = $this.scriptFileActionKeys
+
+        $entry.UserData = @{
+            ScriptBlock = $this.scriptFileCallback
+            ArgumentList = $filePath
+        }
+
+        $this.entries.Add($entry)
+        $this.isEntryUpdated = $true
+    }
+
+    [bool] UpdateEntries() {
+        $updated = $this.isEntryUpdated
+        $this.isEntryUpdated = $false
+        return $updated
+    }
+}
+

--- a/module/PowerShellRun/Public/Add-PSRunScriptBlock.ps1
+++ b/module/PowerShellRun/Public/Add-PSRunScriptBlock.ps1
@@ -1,0 +1,28 @@
+<#
+.SYNOPSIS
+Adds a ScriptBlock as an entry.
+#>
+function Add-PSRunScriptBlock {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+        [ScriptBlock]$ScriptBlock,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [String]$Icon,
+
+        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+        [String]$Name,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [String]$Description,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [String[]]$Preview
+    )
+
+    process {
+        $registry = $script:globalStore.GetRegistry('ScriptRegistry')
+        $registry.AddScriptBlock($ScriptBlock, $Icon, $Name, $Description, $Preview)
+    }
+}

--- a/module/PowerShellRun/Public/Add-PSRunScriptFile.ps1
+++ b/module/PowerShellRun/Public/Add-PSRunScriptFile.ps1
@@ -1,0 +1,28 @@
+<#
+.SYNOPSIS
+Adds a script file as an entry.
+#>
+function Add-PSRunScriptFile {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+        [String]$Path,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [String]$Icon,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [String]$Name,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [String]$Description,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [String[]]$Preview
+    )
+
+    process {
+        $registry = $script:globalStore.GetRegistry('ScriptRegistry')
+        $registry.AddScriptFile($Path, $Icon, $Name, $Description, $Preview)
+    }
+}

--- a/module/PowerShellRun/Public/Enable-PSRunEntry.ps1
+++ b/module/PowerShellRun/Public/Enable-PSRunEntry.ps1
@@ -5,12 +5,12 @@ Initializes PSRun entries.
 function Enable-PSRunEntry {
     [CmdletBinding()]
     param (
-        [ValidateSet('All', 'Application', 'Executable', 'Function', 'Utility', 'Favorite')]
+        [ValidateSet('All', 'Application', 'Executable', 'Function', 'Utility', 'Favorite', 'Script')]
         [String[]]$Category = 'All'
     )
 
     if ($Category -contains 'All') {
-        $Category = 'Application', 'Executable', 'Function', 'Utility', 'Favorite'
+        $Category = 'Application', 'Executable', 'Function', 'Utility', 'Favorite', 'Script'
     }
     $script:globalStore.EnableEntries($Category)
 }

--- a/module/PowerShellRun/Public/Set-PSRunDefaultEditorScript.ps1
+++ b/module/PowerShellRun/Public/Set-PSRunDefaultEditorScript.ps1
@@ -11,7 +11,6 @@ function Set-PSRunDefaultEditorScript {
     )
 
     process {
-        $fileSystemRegistry = $script:globalStore.GetRegistry('FileSystemRegistry')
-        $fileSystemRegistry.SetDefaultEditorScript($ScriptBlock)
+        $script:globalStore.SetDefaultEditorScript($ScriptBlock)
     }
 }

--- a/tests/Public/Add-PSRunScriptBlock.Tests.ps1
+++ b/tests/Public/Add-PSRunScriptBlock.Tests.ps1
@@ -1,0 +1,17 @@
+﻿Describe 'Add-PSRunScriptBlock' {
+    BeforeEach {
+        Import-Module $PSScriptRoot/../../module/PowerShellRun -Force
+    }
+
+    It 'should add an entry' {
+        Add-PSRunScriptBlock -ScriptBlock { 'hello' } -Icon '😆' -Name 'Custom Name' -Description 'Custom Desc' -Preview 'Custom Preview'
+        InModuleScope 'PowerShellRun' {
+            $registry = $script:globalStore.GetRegistry('ScriptRegistry')
+            $registry.entries.Count | Should -Be 1
+        }
+    }
+
+    AfterEach {
+        Remove-Module PowerShellRun -Force
+    }
+}

--- a/tests/Public/Add-PSRunScriptFile.Tests.ps1
+++ b/tests/Public/Add-PSRunScriptFile.Tests.ps1
@@ -1,0 +1,17 @@
+﻿Describe 'Add-PSRunScriptFile' {
+    BeforeEach {
+        Import-Module $PSScriptRoot/../../module/PowerShellRun -Force
+    }
+
+    It 'should add an entry' {
+        Add-PSRunScriptFile -Path 'D:/test.ps1' -Icon '😆' -Name 'Custom Name' -Description 'Custom Desc' -Preview 'Custom Preview'
+        InModuleScope 'PowerShellRun' {
+            $registry = $script:globalStore.GetRegistry('ScriptRegistry')
+            $registry.entries.Count | Should -Be 1
+        }
+    }
+
+    AfterEach {
+        Remove-Module PowerShellRun -Force
+    }
+}

--- a/tests/Public/Set-PSRunDefaultEditorScript.Tests.ps1
+++ b/tests/Public/Set-PSRunDefaultEditorScript.Tests.ps1
@@ -13,8 +13,7 @@
 
         InModuleScope 'PowerShellRun' -ArgumentList $script {
             param($script)
-            $fileSystemRegistry = $script:globalStore.GetRegistry('FileSystemRegistry')
-            $fileSystemRegistry.defaultEditorScript | Should -Be $script
+            $script:globalStore.defaultEditorScript | Should -Be $script
         }
     }
 


### PR DESCRIPTION
Fixes #38 

This PR adds support for ScriptBlock and Script File entries.

```powershell
Add-PSRunScriptBlock -Name 'Test ScriptBlock' -ScriptBlock {
    'This is a test ScriptBlock'
}

Add-PSRunScriptFile -Path 'D:\PowerShellRun\tests\TestScriptFile.ps1' -Icon '💎'
```

![image](https://github.com/mdgrs-mei/PowerShellRun/assets/81177095/474c41da-37bd-49ac-bd95-4a303b601c65)
