### PR TITLE
Entry Group

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,11 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "PowerShell Attach to Host Process",
+            "type": "PowerShell",
+            "request": "attach"
+        },
+        {
             "name": ".NET Core Attach",
             "type": "coreclr",
             "request": "attach"

--- a/module/PowerShellRun/PowerShellRun.psd1
+++ b/module/PowerShellRun/PowerShellRun.psd1
@@ -62,6 +62,7 @@
 
     # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
     FunctionsToExport = @(
+        'Add-PSRunEntryGroup'
         'Add-PSRunFavoriteFile'
         'Add-PSRunFavoriteFolder'
         'Add-PSRunScriptBlock'

--- a/module/PowerShellRun/Private/ApplicationRegistry.ps1
+++ b/module/PowerShellRun/Private/ApplicationRegistry.ps1
@@ -15,9 +15,6 @@ class ApplicationRegistry : EntryRegistry {
     }
 
     [void] InitializeEntries([String[]]$categories) {
-        # Wait for the previous job if exists
-        $this.UpdateEntries()
-
         if ($script:isWindows) {
             $this.StartRegisterEntriesWindows($categories)
         } elseif ($script:isMacOs) {

--- a/module/PowerShellRun/Private/ApplicationRegistry.ps1
+++ b/module/PowerShellRun/Private/ApplicationRegistry.ps1
@@ -14,7 +14,7 @@ class ApplicationRegistry : EntryRegistry {
         return $entries
     }
 
-    [void] EnableEntries([String[]]$categories) {
+    [void] InitializeEntries([String[]]$categories) {
         # Wait for the previous job if exists
         $this.UpdateEntries()
 

--- a/module/PowerShellRun/Private/EntryGroupRegistry.ps1
+++ b/module/PowerShellRun/Private/EntryGroupRegistry.ps1
@@ -10,6 +10,7 @@ class EntryGroupRegistry : EntryRegistry {
 
     $actionKeys
     $callback
+    $previewScript
 
     [System.Collections.Generic.List[PowerShellRun.SelectorEntry]] GetEntries([String[]]$categories) {
         if ($categories -contains 'EntryGroup') {
@@ -85,6 +86,13 @@ class EntryGroupRegistry : EntryRegistry {
                 }
             }
         }
+
+        $this.previewScript = {
+            param($group)
+            $group.Entries | ForEach-Object {
+                $_.Icon + ' ' + $_.Name
+            }
+        }
     }
 
     [EntryGroup] AddEntryGroup($icon, $name, $description, $preview, [String[]]$categories, [EntryGroup]$parentGroup) {
@@ -100,6 +108,9 @@ class EntryGroupRegistry : EntryRegistry {
         $entry.Description = $description
         if ($preview) {
             $entry.Preview = $preview
+        } else {
+            $entry.PreviewAsyncScript = $this.previewScript
+            $entry.PreviewAsyncScriptArgumentList = $group
         }
         $entry.ActionKeys = $this.actionKeys
 

--- a/module/PowerShellRun/Private/EntryGroupRegistry.ps1
+++ b/module/PowerShellRun/Private/EntryGroupRegistry.ps1
@@ -10,8 +10,8 @@ class EntryGroupRegistry : EntryRegistry {
     $actionKeys
     $callback
 
-    [System.Collections.Generic.List[PowerShellRun.SelectorEntry]] GetEntries() {
-        if ($this.isEnabled) {
+    [System.Collections.Generic.List[PowerShellRun.SelectorEntry]] GetEntries([String[]]$categories) {
+        if ($this.isEnabled -and ($categories -contains 'EntryGroup')) {
             return $this.entries
         }
         return $null
@@ -39,6 +39,11 @@ class EntryGroupRegistry : EntryRegistry {
         $this.callback = {
             $result = $args[0].Result
             $group = $args[0].ArgumentList
+
+            if (-not $group.ChildEntries.Count) {
+                Write-Error -Message 'There is no entry.' -Category InvalidOperation
+                return
+            }
 
             if ($result.KeyCombination -eq $script:globalStore.firstActionKey) {
                 $option = $script:globalStore.psRunSelectorOption.DeepClone()
@@ -101,15 +106,12 @@ class EntryGroupRegistry : EntryRegistry {
         return $group
     }
 
-    [EntryGroup] GetCategoryGroup([String]$category) {
-        foreach ($group in $this.categoryGroups) {
-            foreach ($groupCategory in $group.Categories) {
-                if ($groupCategory -eq $category) {
-                    return $group
-                }
-            }
+    [System.Collections.Generic.List[EntryGroup]] GetCategoryGroups() {
+        if ($this.isEnabled) {
+            return $this.categoryGroups
+        } else {
+            return $null
         }
-        return $null
     }
 }
 

--- a/module/PowerShellRun/Private/EntryGroupRegistry.ps1
+++ b/module/PowerShellRun/Private/EntryGroupRegistry.ps1
@@ -11,18 +11,14 @@ class EntryGroupRegistry : EntryRegistry {
     $callback
 
     [System.Collections.Generic.List[PowerShellRun.SelectorEntry]] GetEntries([String[]]$categories) {
-        if ($this.isEnabled -and ($categories -contains 'EntryGroup')) {
+        if ($categories -contains 'EntryGroup') {
             return $this.entries
         }
         return $null
     }
 
     [void] InitializeEntries([String[]]$categories) {
-        $enabled = $categories -contains 'EntryGroup'
-        if ($this.isEnabled -ne $enabled) {
-            $this.isEntryUpdated = $true
-        }
-        $this.isEnabled = $enabled
+        $this.isEnabled = $categories -contains 'EntryGroup'
     }
 
     [bool] UpdateEntries() {
@@ -80,6 +76,10 @@ class EntryGroupRegistry : EntryRegistry {
     }
 
     [EntryGroup] AddEntryGroup($icon, $name, $description, $preview, [String[]]$categories) {
+        if (-not $this.isEnabled) {
+            return $null
+        }
+
         $group = [EntryGroup]::new($name, $categories)
 
         $entry = [PowerShellRun.SelectorEntry]::new()
@@ -107,11 +107,7 @@ class EntryGroupRegistry : EntryRegistry {
     }
 
     [System.Collections.Generic.List[EntryGroup]] GetCategoryGroups() {
-        if ($this.isEnabled) {
-            return $this.categoryGroups
-        } else {
-            return $null
-        }
+        return $this.categoryGroups
     }
 }
 

--- a/module/PowerShellRun/Private/EntryGroupRegistry.ps1
+++ b/module/PowerShellRun/Private/EntryGroupRegistry.ps1
@@ -1,0 +1,115 @@
+using module ./_EntryGroup.psm1
+using module ./_EntryRegistry.psm1
+
+class EntryGroupRegistry : EntryRegistry {
+    $entries = [System.Collections.Generic.List[PowerShellRun.SelectorEntry]]::new()
+    $categoryGroups = [System.Collections.Generic.List[EntryGroup]]::new()
+    $isEntryUpdated = $false
+    $isEnabled = $false
+
+    $actionKeys
+    $callback
+
+    [System.Collections.Generic.List[PowerShellRun.SelectorEntry]] GetEntries() {
+        if ($this.isEnabled) {
+            return $this.entries
+        }
+        return $null
+    }
+
+    [void] EnableEntries([String[]]$categories) {
+        $enabled = $categories -contains 'EntryGroup'
+        if ($this.isEnabled -ne $enabled) {
+            $this.isEntryUpdated = $true
+        }
+        $this.isEnabled = $enabled
+    }
+
+    [bool] UpdateEntries() {
+        $updated = $this.isEntryUpdated
+        $this.isEntryUpdated = $false
+        return $updated
+    }
+
+    EntryGroupRegistry() {
+        $this.actionKeys = @(
+            [PowerShellRun.ActionKey]::new($script:globalStore.firstActionKey, 'Open group')
+        )
+
+        $this.callback = {
+            $result = $args[0].Result
+            $group = $args[0].ArgumentList
+
+            if ($result.KeyCombination -eq $script:globalStore.firstActionKey) {
+                $option = $script:globalStore.psRunSelectorOption.DeepClone()
+                $option.QuitWithBackspaceOnEmptyQuery = $true
+                $option.Prompt = "$($group.Name)> "
+                $prevContext = $null
+
+                while ($true) {
+                    $script:globalStore.ClearParentSelectorRestoreRequest()
+
+                    $result = Invoke-PSRunSelectorCustom -Entry $group.ChildEntries -Option $option -Context $prevContext
+                    $prevContext = $result.Context
+
+                    if ($result.KeyCombination -eq 'Backspace') {
+                        Restore-PSRunParentSelector
+                        return
+                    }
+
+                    if ($result.FocusedEntry) {
+                        $callback = $result.FocusedEntry.UserData.ScriptBlock
+                        $argumentList = @{
+                            Result = $result
+                            ArgumentList = $result.FocusedEntry.UserData.ArgumentList
+                        }
+                        & $callback $argumentList
+                    }
+
+                    if (-not $script:globalStore.IsParentSelectorRestoreRequested()) {
+                        break
+                    }
+                }
+            }
+        }
+    }
+
+    [EntryGroup] AddEntryGroup($icon, $name, $description, $preview, [String[]]$categories) {
+        $group = [EntryGroup]::new($name, $categories)
+
+        $entry = [PowerShellRun.SelectorEntry]::new()
+        $entry.Icon = if ($icon) { $icon } else { '📂' }
+        $entry.Name = $name
+        $entry.Description = $description
+        if ($preview) {
+            $entry.Preview = $preview
+        }
+        $entry.ActionKeys = $this.actionKeys
+
+        $entry.UserData = @{
+            ScriptBlock = $this.callback
+            ArgumentList = $group
+        }
+
+        $this.entries.Add($entry)
+        $this.isEntryUpdated = $true
+
+        if ($categories) {
+            $this.categoryGroups.Add($group)
+        }
+
+        return $group
+    }
+
+    [EntryGroup] GetCategoryGroup([String]$category) {
+        foreach ($group in $this.categoryGroups) {
+            foreach ($groupCategory in $group.Categories) {
+                if ($groupCategory -eq $category) {
+                    return $group
+                }
+            }
+        }
+        return $null
+    }
+}
+

--- a/module/PowerShellRun/Private/EntryGroupRegistry.ps1
+++ b/module/PowerShellRun/Private/EntryGroupRegistry.ps1
@@ -21,6 +21,10 @@ class EntryGroupRegistry : EntryRegistry {
         $this.isEnabled = $categories -contains 'EntryGroup'
     }
 
+    [void] SetEntriesDirty() {
+        $this.isEntryUpdated = $true
+    }
+
     [bool] UpdateEntries() {
         $updated = $this.isEntryUpdated
         $this.isEntryUpdated = $false
@@ -36,7 +40,7 @@ class EntryGroupRegistry : EntryRegistry {
             $result = $args[0].Result
             $group = $args[0].ArgumentList
 
-            if (-not $group.ChildEntries.Count) {
+            if (-not $group.Entries.Count) {
                 Write-Error -Message 'There is no entry.' -Category InvalidOperation
                 return
             }
@@ -50,7 +54,7 @@ class EntryGroupRegistry : EntryRegistry {
                 while ($true) {
                     $script:globalStore.ClearParentSelectorRestoreRequest()
 
-                    $result = Invoke-PSRunSelectorCustom -Entry $group.ChildEntries -Option $option -Context $prevContext
+                    $result = Invoke-PSRunSelectorCustom -Entry $group.Entries -Option $option -Context $prevContext
                     $prevContext = $result.Context
 
                     if ($result.KeyCombination -eq 'Backspace') {
@@ -80,7 +84,7 @@ class EntryGroupRegistry : EntryRegistry {
             return $null
         }
 
-        $group = [EntryGroup]::new($name, $categories)
+        $group = [EntryGroup]::new($this, $name, $categories)
 
         $entry = [PowerShellRun.SelectorEntry]::new()
         $entry.Icon = if ($icon) { $icon } else { '📂' }
@@ -97,7 +101,7 @@ class EntryGroupRegistry : EntryRegistry {
         }
 
         $this.entries.Add($entry)
-        $this.isEntryUpdated = $true
+        $this.SetEntriesDirty()
 
         if ($categories) {
             $this.categoryGroups.Add($group)

--- a/module/PowerShellRun/Private/EntryGroupRegistry.ps1
+++ b/module/PowerShellRun/Private/EntryGroupRegistry.ps1
@@ -17,7 +17,7 @@ class EntryGroupRegistry : EntryRegistry {
         return $null
     }
 
-    [void] EnableEntries([String[]]$categories) {
+    [void] InitializeEntries([String[]]$categories) {
         $enabled = $categories -contains 'EntryGroup'
         if ($this.isEnabled -ne $enabled) {
             $this.isEntryUpdated = $true

--- a/module/PowerShellRun/Private/FileSystemRegistry.ps1
+++ b/module/PowerShellRun/Private/FileSystemRegistry.ps1
@@ -43,12 +43,12 @@ class FileSystemRegistry : EntryRegistry {
         }
     }
 
-    [System.Collections.Generic.List[PowerShellRun.SelectorEntry]] GetEntries() {
+    [System.Collections.Generic.List[PowerShellRun.SelectorEntry]] GetEntries([String[]]$categories) {
         $entries = [System.Collections.Generic.List[PowerShellRun.SelectorEntry]]::new()
-        if ($this.isFavoritesEnabled) {
+        if ($this.isFavoritesEnabled -and ($categories -contains 'Favorite')) {
             $entries.AddRange($this.favoritesEntries)
         }
-        if ($this.isFileManagerEnabled) {
+        if ($this.isFileManagerEnabled -and ($categories -contains 'Utility')) {
             $entries.AddRange($this.fileManagerEntry)
         }
         return $entries
@@ -131,11 +131,6 @@ class FileSystemRegistry : EntryRegistry {
 
         $this.favoritesEntries.Add($entry)
         $this.isEntryUpdated = $true
-
-        $group = $script:globalStore.GetCategoryGroup('Favorite')
-        if ($group) {
-            $group.AddEntry($entry)
-        }
     }
 
     [void] AddFavoriteFile($filePath, $icon, $name, $description, $preview) {

--- a/module/PowerShellRun/Private/FileSystemRegistry.ps1
+++ b/module/PowerShellRun/Private/FileSystemRegistry.ps1
@@ -1,4 +1,6 @@
+using module ./_EntryGroup.psm1
 using module ./_EntryRegistry.psm1
+
 class FileSystemRegistry : EntryRegistry {
     $favoritesEntries = [System.Collections.Generic.List[PowerShellRun.SelectorEntry]]::new()
     $fileManagerEntry = [System.Collections.Generic.List[PowerShellRun.SelectorEntry]]::new()
@@ -96,7 +98,7 @@ class FileSystemRegistry : EntryRegistry {
         $this.fileManagerEntry.Add($entry)
     }
 
-    [void] AddFavoriteFolder($folderPath, $icon, $name, $description, $preview) {
+    [void] AddFavoriteFolder($folderPath, $icon, $name, $description, $preview, [EntryGroup]$entryGroup) {
         if (-not $this.isFavoritesEnabled) {
             return
         }
@@ -133,11 +135,15 @@ class FileSystemRegistry : EntryRegistry {
             ArgumentList = $this.fileManagerArguments, $folderPath
         }
 
-        $this.favoritesEntries.Add($entry)
-        $this.isEntryUpdated = $true
+        if ($entryGroup) {
+            $entryGroup.AddEntry($entry)
+        } else {
+            $this.favoritesEntries.Add($entry)
+            $this.isEntryUpdated = $true
+        }
     }
 
-    [void] AddFavoriteFile($filePath, $icon, $name, $description, $preview) {
+    [void] AddFavoriteFile($filePath, $icon, $name, $description, $preview, [EntryGroup]$entryGroup) {
         if (-not $this.isFavoritesEnabled) {
             return
         }
@@ -174,8 +180,12 @@ class FileSystemRegistry : EntryRegistry {
             ArgumentList = $filePath
         }
 
-        $this.favoritesEntries.Add($entry)
-        $this.isEntryUpdated = $true
+        if ($entryGroup) {
+            $entryGroup.AddEntry($entry)
+        } else {
+            $this.favoritesEntries.Add($entry)
+            $this.isEntryUpdated = $true
+        }
     }
 
     $fileManagerLoop = {

--- a/module/PowerShellRun/Private/FileSystemRegistry.ps1
+++ b/module/PowerShellRun/Private/FileSystemRegistry.ps1
@@ -45,10 +45,10 @@ class FileSystemRegistry : EntryRegistry {
 
     [System.Collections.Generic.List[PowerShellRun.SelectorEntry]] GetEntries([String[]]$categories) {
         $entries = [System.Collections.Generic.List[PowerShellRun.SelectorEntry]]::new()
-        if ($this.isFavoritesEnabled -and ($categories -contains 'Favorite')) {
+        if ($categories -contains 'Favorite') {
             $entries.AddRange($this.favoritesEntries)
         }
-        if ($this.isFileManagerEnabled -and ($categories -contains 'Utility')) {
+        if ($categories -contains 'Utility') {
             $entries.AddRange($this.fileManagerEntry)
         }
         return $entries
@@ -97,6 +97,10 @@ class FileSystemRegistry : EntryRegistry {
     }
 
     [void] AddFavoriteFolder($folderPath, $icon, $name, $description, $preview) {
+        if (-not $this.isFavoritesEnabled) {
+            return
+        }
+
         $callback = {
             $result = $args[0].Result
             $arguments, $path = $args[0].ArgumentList
@@ -134,6 +138,10 @@ class FileSystemRegistry : EntryRegistry {
     }
 
     [void] AddFavoriteFile($filePath, $icon, $name, $description, $preview) {
+        if (-not $this.isFavoritesEnabled) {
+            return
+        }
+
         $callback = {
             $result = $args[0].Result
             $path = $args[0].ArgumentList

--- a/module/PowerShellRun/Private/FileSystemRegistry.ps1
+++ b/module/PowerShellRun/Private/FileSystemRegistry.ps1
@@ -54,7 +54,7 @@ class FileSystemRegistry : EntryRegistry {
         return $entries
     }
 
-    [void] EnableEntries([String[]]$categories) {
+    [void] InitializeEntries([String[]]$categories) {
         $this.isEntryUpdated = $true
 
         $this.isFavoritesEnabled = $categories -contains 'Favorite'

--- a/module/PowerShellRun/Private/FileSystemRegistry.ps1
+++ b/module/PowerShellRun/Private/FileSystemRegistry.ps1
@@ -131,6 +131,11 @@ class FileSystemRegistry : EntryRegistry {
 
         $this.favoritesEntries.Add($entry)
         $this.isEntryUpdated = $true
+
+        $group = $script:globalStore.GetCategoryGroup('Favorite')
+        if ($group) {
+            $group.AddEntry($entry)
+        }
     }
 
     [void] AddFavoriteFile($filePath, $icon, $name, $description, $preview) {

--- a/module/PowerShellRun/Private/FunctionRegistry.ps1
+++ b/module/PowerShellRun/Private/FunctionRegistry.ps1
@@ -8,18 +8,14 @@ class FunctionRegistry : EntryRegistry {
     $actionKeys
 
     [System.Collections.Generic.List[PowerShellRun.SelectorEntry]] GetEntries([String[]]$categories) {
-        if ($this.isEnabled -and ($categories -contains 'Function')) {
+        if ($categories -contains 'Function') {
             return $this.entries
         }
         return $null
     }
 
     [void] InitializeEntries([String[]]$categories) {
-        $enabled = $categories -contains 'Function'
-        if ($this.isEnabled -ne $enabled) {
-            $this.isEntryUpdated = $true
-        }
-        $this.isEnabled = $enabled
+        $this.isEnabled = $categories -contains 'Function'
     }
 
     FunctionRegistry() {
@@ -56,6 +52,10 @@ class FunctionRegistry : EntryRegistry {
     [void] StopRegistration($errorAction) {
         if ($null -eq $this.functionsAtRegisterStart) {
             Write-Error -Message 'Function registration has not started yet.' -Category InvalidOperation -ErrorAction $errorAction
+            return
+        }
+        if (-not $this.isEnabled) {
+            $this.functionsAtRegisterStart = $null
             return
         }
 

--- a/module/PowerShellRun/Private/FunctionRegistry.ps1
+++ b/module/PowerShellRun/Private/FunctionRegistry.ps1
@@ -7,8 +7,8 @@ class FunctionRegistry : EntryRegistry {
     $callback
     $actionKeys
 
-    [System.Collections.Generic.List[PowerShellRun.SelectorEntry]] GetEntries() {
-        if ($this.isEnabled) {
+    [System.Collections.Generic.List[PowerShellRun.SelectorEntry]] GetEntries([String[]]$categories) {
+        if ($this.isEnabled -and ($categories -contains 'Function')) {
             return $this.entries
         }
         return $null

--- a/module/PowerShellRun/Private/FunctionRegistry.ps1
+++ b/module/PowerShellRun/Private/FunctionRegistry.ps1
@@ -14,7 +14,7 @@ class FunctionRegistry : EntryRegistry {
         return $null
     }
 
-    [void] EnableEntries([String[]]$categories) {
+    [void] InitializeEntries([String[]]$categories) {
         $enabled = $categories -contains 'Function'
         if ($this.isEnabled -ne $enabled) {
             $this.isEntryUpdated = $true

--- a/module/PowerShellRun/Private/GlobalStore.ps1
+++ b/module/PowerShellRun/Private/GlobalStore.ps1
@@ -113,9 +113,9 @@ class GlobalStore {
         return $null
     }
 
-    [void] EnableEntries([String[]]$entryCategories) {
+    [void] InitializeEntries([String[]]$entryCategories) {
         foreach ($registry in $this.registries) {
-            $registry.EnableEntries($entryCategories)
+            $registry.InitializeEntries($entryCategories)
         }
     }
 

--- a/module/PowerShellRun/Private/GlobalStore.ps1
+++ b/module/PowerShellRun/Private/GlobalStore.ps1
@@ -140,16 +140,17 @@ class GlobalStore {
             $ungroupedCategories = $this.allCategoryNames
 
             foreach ($categoryGroup in $categoryGroups) {
-                $categoryGroup.ClearEntries()
+                $categoryGroup.ClearCategoryEntries()
                 foreach ($registry in $this.registries) {
                     if ($_entries = $registry.GetEntries($categoryGroup.Categories)) {
-                        $categoryGroup.AddEntries($_entries)
+                        $categoryGroup.AddCategoryEntries($_entries)
                     }
 
                     foreach ($groupCategory in $categoryGroup.Categories) {
                         $ungroupedCategories = $ungroupedCategories -ne $groupCategory
                     }
                 }
+                $categoryGroup.UpdateEntries()
             }
 
             foreach ($registry in $this.registries) {

--- a/module/PowerShellRun/Private/GlobalStore.ps1
+++ b/module/PowerShellRun/Private/GlobalStore.ps1
@@ -1,4 +1,5 @@
 using module ./_EntryRegistry.psm1
+using module ./_EntryGroup.psm1
 
 class GlobalStore {
     $entries = [System.Collections.Generic.List[PowerShellRun.SelectorEntry]]::new()
@@ -11,6 +12,7 @@ class GlobalStore {
         'FileSystemRegistry'
         'WinGetRegistry'
         'ApplicationRegistry'
+        'EntryGroupRegistry'
     )
     $registries = [System.Collections.Generic.List[EntryRegistry]]::new()
 
@@ -119,6 +121,11 @@ class GlobalStore {
                 }
             }
         }
+    }
+
+    [EntryGroup] GetCategoryGroup([string]$category) {
+        $registry = $this.GetRegistry('EntryGroupRegistry')
+        return $registry.GetCategoryGroup($category)
     }
 
     [void] RequestParentSelectorRestore() {

--- a/module/PowerShellRun/Private/GlobalStore.ps1
+++ b/module/PowerShellRun/Private/GlobalStore.ps1
@@ -3,6 +3,7 @@ using module ./_EntryGroup.psm1
 
 class GlobalStore {
     $entries = [System.Collections.Generic.List[PowerShellRun.SelectorEntry]]::new()
+    $isEntryInitialized = $false
     $defaultSelectorOption = [PowerShellRun.SelectorOption]::new()
     $psRunSelectorOption = [PowerShellRun.SelectorOption]::new()
 
@@ -114,9 +115,17 @@ class GlobalStore {
     }
 
     [void] InitializeEntries([String[]]$entryCategories) {
+        if ($this.isEntryInitialized) {
+            return
+        }
         foreach ($registry in $this.registries) {
             $registry.InitializeEntries($entryCategories)
         }
+        $this.isEntryInitialized = $true
+    }
+
+    [bool] IsEntriesInitialized() {
+        return $this.isEntryInitialized
     }
 
     [void] UpdateEntries() {

--- a/module/PowerShellRun/Private/GlobalStore.ps1
+++ b/module/PowerShellRun/Private/GlobalStore.ps1
@@ -7,7 +7,7 @@ class GlobalStore {
     $defaultSelectorOption = [PowerShellRun.SelectorOption]::new()
     $psRunSelectorOption = [PowerShellRun.SelectorOption]::new()
 
-    # When you add a new category, you also need to add to the ValidateSet of Enable-PSRunEntry.
+    # When you add a new category, you also need to add to the ValidateSet of Enable-PSRunEntry and Add-PSRunEntryGroup.
     $allCategoryNames = @(
         'Application'
         'Executable'
@@ -18,12 +18,12 @@ class GlobalStore {
         'EntryGroup'
     )
     $registryClassNames = @(
+        'EntryGroupRegistry'
         'FunctionRegistry'
         'ScriptRegistry'
         'FileSystemRegistry'
         'WinGetRegistry'
         'ApplicationRegistry'
-        'EntryGroupRegistry'
     )
     $registries = [System.Collections.Generic.List[EntryRegistry]]::new()
     $entryGroupRegistry = $null

--- a/module/PowerShellRun/Private/ScriptRegistry.ps1
+++ b/module/PowerShellRun/Private/ScriptRegistry.ps1
@@ -11,18 +11,14 @@ class ScriptRegistry : EntryRegistry {
     $scriptFilePreviewScript
 
     [System.Collections.Generic.List[PowerShellRun.SelectorEntry]] GetEntries([String[]]$categories) {
-        if ($this.isEnabled -and ($categories -contains 'Script')) {
+        if ($categories -contains 'Script') {
             return $this.entries
         }
         return $null
     }
 
     [void] InitializeEntries([String[]]$categories) {
-        $enabled = $categories -contains 'Script'
-        if ($this.isEnabled -ne $enabled) {
-            $this.isEntryUpdated = $true
-        }
-        $this.isEnabled = $enabled
+        $this.isEnabled = $categories -contains 'Script'
     }
 
     ScriptRegistry() {
@@ -74,6 +70,10 @@ class ScriptRegistry : EntryRegistry {
     }
 
     [void] AddScriptBlock($scriptBlock, $icon, $name, $description, $preview) {
+        if (-not $this.isEnabled) {
+            return
+        }
+
         $entry = [PowerShellRun.SelectorEntry]::new()
         $entry.Icon = if ($icon) { $icon } else { '{}' }
         $entry.Name = $name
@@ -95,6 +95,10 @@ class ScriptRegistry : EntryRegistry {
     }
 
     [void] AddScriptFile($filePath, $icon, $name, $description, $preview) {
+        if (-not $this.isEnabled) {
+            return
+        }
+
         $entry = [PowerShellRun.SelectorEntry]::new()
         $entry.Icon = if ($icon) { $icon } else { '📘' }
         $entry.Name = if ($name) { $name } else { Split-Path $filePath -Leaf }

--- a/module/PowerShellRun/Private/ScriptRegistry.ps1
+++ b/module/PowerShellRun/Private/ScriptRegistry.ps1
@@ -17,7 +17,7 @@ class ScriptRegistry : EntryRegistry {
         return $null
     }
 
-    [void] EnableEntries([String[]]$categories) {
+    [void] InitializeEntries([String[]]$categories) {
         $enabled = $categories -contains 'Script'
         if ($this.isEnabled -ne $enabled) {
             $this.isEntryUpdated = $true

--- a/module/PowerShellRun/Private/ScriptRegistry.ps1
+++ b/module/PowerShellRun/Private/ScriptRegistry.ps1
@@ -10,8 +10,8 @@ class ScriptRegistry : EntryRegistry {
     $scriptFileCallback
     $scriptFilePreviewScript
 
-    [System.Collections.Generic.List[PowerShellRun.SelectorEntry]] GetEntries() {
-        if ($this.isEnabled) {
+    [System.Collections.Generic.List[PowerShellRun.SelectorEntry]] GetEntries([String[]]$categories) {
+        if ($this.isEnabled -and ($categories -contains 'Script')) {
             return $this.entries
         }
         return $null

--- a/module/PowerShellRun/Private/ScriptRegistry.ps1
+++ b/module/PowerShellRun/Private/ScriptRegistry.ps1
@@ -1,4 +1,6 @@
+using module ./_EntryGroup.psm1
 using module ./_EntryRegistry.psm1
+
 class ScriptRegistry : EntryRegistry {
     $entries = [System.Collections.Generic.List[PowerShellRun.SelectorEntry]]::new()
     $isEntryUpdated = $false
@@ -69,7 +71,7 @@ class ScriptRegistry : EntryRegistry {
         }
     }
 
-    [void] AddScriptBlock($scriptBlock, $icon, $name, $description, $preview) {
+    [void] AddScriptBlock($scriptBlock, $icon, $name, $description, $preview, [EntryGroup]$entryGroup) {
         if (-not $this.isEnabled) {
             return
         }
@@ -90,11 +92,15 @@ class ScriptRegistry : EntryRegistry {
             ArgumentList = $scriptBlock
         }
 
-        $this.entries.Add($entry)
-        $this.isEntryUpdated = $true
+        if ($entryGroup) {
+            $entryGroup.AddEntry($entry)
+        } else {
+            $this.entries.Add($entry)
+            $this.isEntryUpdated = $true
+        }
     }
 
-    [void] AddScriptFile($filePath, $icon, $name, $description, $preview) {
+    [void] AddScriptFile($filePath, $icon, $name, $description, $preview, [EntryGroup]$entryGroup) {
         if (-not $this.isEnabled) {
             return
         }
@@ -116,8 +122,12 @@ class ScriptRegistry : EntryRegistry {
             ArgumentList = $filePath
         }
 
-        $this.entries.Add($entry)
-        $this.isEntryUpdated = $true
+        if ($entryGroup) {
+            $entryGroup.AddEntry($entry)
+        } else {
+            $this.entries.Add($entry)
+            $this.isEntryUpdated = $true
+        }
     }
 
     [bool] UpdateEntries() {

--- a/module/PowerShellRun/Private/WinGetRegistry.ps1
+++ b/module/PowerShellRun/Private/WinGetRegistry.ps1
@@ -9,8 +9,8 @@ class WinGetRegistry : EntryRegistry {
     WinGetRegistry() {
     }
 
-    [System.Collections.Generic.List[PowerShellRun.SelectorEntry]] GetEntries() {
-        if ($this.isEnabled) {
+    [System.Collections.Generic.List[PowerShellRun.SelectorEntry]] GetEntries([String[]]$categories) {
+        if ($this.isEnabled -and ($categories -contains 'Utility')) {
             return $this.entries
         }
         return $null

--- a/module/PowerShellRun/Private/WinGetRegistry.ps1
+++ b/module/PowerShellRun/Private/WinGetRegistry.ps1
@@ -3,14 +3,13 @@ class WinGetRegistry : EntryRegistry {
     $entries = [System.Collections.Generic.List[PowerShellRun.SelectorEntry]]::new()
     $subMenuEntries = [System.Collections.Generic.List[PowerShellRun.SelectorEntry]]::new()
     $isEntryUpdated = $false
-    $isEnabled = $false
     $restoreParentMenu = $false
 
     WinGetRegistry() {
     }
 
     [System.Collections.Generic.List[PowerShellRun.SelectorEntry]] GetEntries([String[]]$categories) {
-        if ($this.isEnabled -and ($categories -contains 'Utility')) {
+        if ($categories -contains 'Utility') {
             return $this.entries
         }
         return $null
@@ -20,12 +19,6 @@ class WinGetRegistry : EntryRegistry {
         $enabled = $categories -contains 'Utility'
         $enabled = $enabled -and $this.IsWinGetInstalled()
 
-        if ($this.isEnabled -ne $enabled) {
-            $this.isEntryUpdated = $true
-        }
-        $this.isEnabled = $enabled
-
-        $this.entries.Clear()
         if ($enabled) {
             $this.RegisterEntries()
         }
@@ -96,6 +89,8 @@ class WinGetRegistry : EntryRegistry {
         $this.subMenuEntries.Add($this.CreateInstallEntry())
         $this.subMenuEntries.Add($this.CreateUpgradeEntry())
         $this.subMenuEntries.Add($this.CreateUninstallEntry())
+
+        $this.isEntryUpdated = $true
     }
 
     [PowerShellRun.SelectorEntry] CreatePackageEntry($package) {

--- a/module/PowerShellRun/Private/WinGetRegistry.ps1
+++ b/module/PowerShellRun/Private/WinGetRegistry.ps1
@@ -16,7 +16,7 @@ class WinGetRegistry : EntryRegistry {
         return $null
     }
 
-    [void] EnableEntries([String[]]$categories) {
+    [void] InitializeEntries([String[]]$categories) {
         $enabled = $categories -contains 'Utility'
         $enabled = $enabled -and $this.IsWinGetInstalled()
 

--- a/module/PowerShellRun/Private/_EntryGroup.psm1
+++ b/module/PowerShellRun/Private/_EntryGroup.psm1
@@ -1,0 +1,15 @@
+class EntryGroup {
+    [String]$Name
+    [String[]]$Categories
+    [System.Collections.Generic.List[PowerShellRun.SelectorEntry]]$ChildEntries = [System.Collections.Generic.List[PowerShellRun.SelectorEntry]]::new()
+
+    EntryGroup([String]$name, [String[]]$categories) {
+        $this.Name = $name
+        $this.Categories = $categories
+    }
+
+    [void] AddEntry([PowerShellRun.SelectorEntry]$entry) {
+        $this.ChildEntries.Add($entry)
+    }
+}
+

--- a/module/PowerShellRun/Private/_EntryGroup.psm1
+++ b/module/PowerShellRun/Private/_EntryGroup.psm1
@@ -11,5 +11,12 @@ class EntryGroup {
     [void] AddEntry([PowerShellRun.SelectorEntry]$entry) {
         $this.ChildEntries.Add($entry)
     }
-}
 
+    [void] AddEntries([System.Collections.Generic.List[PowerShellRun.SelectorEntry]]$entries) {
+        $this.ChildEntries.AddRange($entries)
+    }
+
+    [void] ClearEntries() {
+        $this.ChildEntries.Clear()
+    }
+}

--- a/module/PowerShellRun/Private/_EntryGroup.psm1
+++ b/module/PowerShellRun/Private/_EntryGroup.psm1
@@ -35,8 +35,8 @@ class EntryGroup {
         }
 
         $this.Entries.Clear()
-        $this.Entries.AddRange($this.DirectChildEntries)
         $this.Entries.AddRange($this.CategoryEntries)
+        $this.Entries.AddRange($this.DirectChildEntries)
         $this.IsEntryUpdated = $false
     }
 }

--- a/module/PowerShellRun/Private/_EntryGroup.psm1
+++ b/module/PowerShellRun/Private/_EntryGroup.psm1
@@ -1,22 +1,42 @@
 class EntryGroup {
+    [Object]$Registry
     [String]$Name
     [String[]]$Categories
-    [System.Collections.Generic.List[PowerShellRun.SelectorEntry]]$ChildEntries = [System.Collections.Generic.List[PowerShellRun.SelectorEntry]]::new()
+    [System.Collections.Generic.List[PowerShellRun.SelectorEntry]]$CategoryEntries = [System.Collections.Generic.List[PowerShellRun.SelectorEntry]]::new()
+    [System.Collections.Generic.List[PowerShellRun.SelectorEntry]]$DirectChildEntries = [System.Collections.Generic.List[PowerShellRun.SelectorEntry]]::new()
+    [System.Collections.Generic.List[PowerShellRun.SelectorEntry]]$Entries = [System.Collections.Generic.List[PowerShellRun.SelectorEntry]]::new()
+    [bool]$IsEntryUpdated = $false
 
-    EntryGroup([String]$name, [String[]]$categories) {
+    EntryGroup([Object]$registry, [String]$name, [String[]]$categories) {
+        $this.Registry = $registry
         $this.Name = $name
         $this.Categories = $categories
     }
 
     [void] AddEntry([PowerShellRun.SelectorEntry]$entry) {
-        $this.ChildEntries.Add($entry)
+        $this.DirectChildEntries.Add($entry)
+        $this.IsEntryUpdated = $true
+        $this.registry.SetEntriesDirty()
     }
 
-    [void] AddEntries([System.Collections.Generic.List[PowerShellRun.SelectorEntry]]$entries) {
-        $this.ChildEntries.AddRange($entries)
+    [void] AddCategoryEntries([System.Collections.Generic.List[PowerShellRun.SelectorEntry]]$entries) {
+        $this.CategoryEntries.AddRange($entries)
+        $this.IsEntryUpdated = $true
     }
 
-    [void] ClearEntries() {
-        $this.ChildEntries.Clear()
+    [void] ClearCategoryEntries() {
+        $this.CategoryEntries.Clear()
+        $this.IsEntryUpdated = $true
+    }
+
+    [void] UpdateEntries() {
+        if (-not $this.IsEntryUpdated) {
+            return
+        }
+
+        $this.Entries.Clear()
+        $this.Entries.AddRange($this.DirectChildEntries)
+        $this.Entries.AddRange($this.CategoryEntries)
+        $this.IsEntryUpdated = $false
     }
 }

--- a/module/PowerShellRun/Private/_EntryRegistry.psm1
+++ b/module/PowerShellRun/Private/_EntryRegistry.psm1
@@ -1,5 +1,5 @@
 class EntryRegistry {
-    [System.Collections.Generic.List[PowerShellRun.SelectorEntry]] GetEntries() {
+    [System.Collections.Generic.List[PowerShellRun.SelectorEntry]] GetEntries([String[]]$categories) {
         Write-Error -Message 'This method needs to be overridden.' -Category NotImplemented
         return $null
     }

--- a/module/PowerShellRun/Private/_EntryRegistry.psm1
+++ b/module/PowerShellRun/Private/_EntryRegistry.psm1
@@ -4,7 +4,7 @@ class EntryRegistry {
         return $null
     }
 
-    [void] EnableEntries([String[]]$categories) {
+    [void] InitializeEntries([String[]]$categories) {
         Write-Error -Message 'This method needs to be overridden.' -Category NotImplemented
     }
 

--- a/module/PowerShellRun/Public/Add-PSRunEntryGroup.ps1
+++ b/module/PowerShellRun/Public/Add-PSRunEntryGroup.ps1
@@ -1,0 +1,38 @@
+<#
+.SYNOPSIS
+Adds an entry group.
+#>
+function Add-PSRunEntryGroup {
+    [CmdletBinding()]
+    param (
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [String]$Icon,
+
+        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+        [String]$Name,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [String]$Description,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [String[]]$Preview,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [String[]]$Category,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [Object]$EntryGroup,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [Switch]$PassThru
+    )
+
+    process {
+        $registry = $script:globalStore.GetRegistry('EntryGroupRegistry')
+        $group = $registry.AddEntryGroup($Icon, $Name, $Description, $Preview, $Category, $EntryGroup)
+
+        if ($PassThru) {
+            $group
+        }
+    }
+}

--- a/module/PowerShellRun/Public/Add-PSRunEntryGroup.ps1
+++ b/module/PowerShellRun/Public/Add-PSRunEntryGroup.ps1
@@ -18,6 +18,7 @@ function Add-PSRunEntryGroup {
         [String[]]$Preview,
 
         [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [ValidateSet('Application', 'Executable', 'Function', 'Utility', 'Favorite', 'Script')]
         [String[]]$Category,
 
         [Parameter(ValueFromPipelineByPropertyName = $true)]

--- a/module/PowerShellRun/Public/Add-PSRunEntryGroup.ps1
+++ b/module/PowerShellRun/Public/Add-PSRunEntryGroup.ps1
@@ -1,6 +1,44 @@
 <#
 .SYNOPSIS
-Adds an entry group.
+Adds an entry group as an entry.
+
+.DESCRIPTION
+Adds an entry group as an entry that can hold other entries as its children. The entry groups belong to the 'EntryGroup' category.
+
+.PARAMETER Icon
+The icon string.
+
+.PARAMETER Name
+The name of the entry.
+
+.PARAMETER Description
+The description string.
+
+.PARAMETER Preview
+The custom preview string. Child entries are listed by default.
+
+.PARAMETER Category
+Specifies a category or an array of categories that the entry group holds.
+If specified, the entries that belong to the category are all added to the entry group instead of being listed in the top menu.
+
+.PARAMETER EntryGroup
+The parent entry group object where this new entry group is added.
+
+.PARAMETER PassThru
+Returns the added entry group if specified.
+
+.INPUTS
+None.
+
+.OUTPUTS
+An object that represents an entry group if PassThru is specified. None otherwise.
+
+.EXAMPLE
+$group = Add-PSRunEntryGroup -Name 'ProjectA' -PassThru
+Add-PSRunScriptBlock -Name 'Hello' -ScriptBlock { 'Hello' } -EntryGroup $group
+
+.EXAMPLE
+Add-PSRunEntryGroup -Name 'Apps' -Category Application
 #>
 function Add-PSRunEntryGroup {
     [CmdletBinding()]

--- a/module/PowerShellRun/Public/Add-PSRunFavoriteFile.ps1
+++ b/module/PowerShellRun/Public/Add-PSRunFavoriteFile.ps1
@@ -20,6 +20,9 @@ The description string. The filepath is used by default.
 .PARAMETER Preview
 The custom preview string.
 
+.PARAMETER EntryGroup
+The parent entry group object where this new entry is added.
+
 .INPUTS
 None.
 

--- a/module/PowerShellRun/Public/Add-PSRunFavoriteFile.ps1
+++ b/module/PowerShellRun/Public/Add-PSRunFavoriteFile.ps1
@@ -48,11 +48,14 @@ function Add-PSRunFavoriteFile {
         [String]$Description,
 
         [Parameter(ValueFromPipelineByPropertyName = $true)]
-        [String[]]$Preview
+        [String[]]$Preview,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [Object]$EntryGroup
     )
 
     process {
         $fileSystemRegistry = $script:globalStore.GetRegistry('FileSystemRegistry')
-        $fileSystemRegistry.AddFavoriteFile($Path, $Icon, $Name, $Description, $Preview)
+        $fileSystemRegistry.AddFavoriteFile($Path, $Icon, $Name, $Description, $Preview, $EntryGroup)
     }
 }

--- a/module/PowerShellRun/Public/Add-PSRunFavoriteFolder.ps1
+++ b/module/PowerShellRun/Public/Add-PSRunFavoriteFolder.ps1
@@ -48,11 +48,14 @@ function Add-PSRunFavoriteFolder {
         [String]$Description,
 
         [Parameter(ValueFromPipelineByPropertyName = $true)]
-        [String[]]$Preview
+        [String[]]$Preview,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [Object]$EntryGroup
     )
 
     process {
         $fileSystemRegistry = $script:globalStore.GetRegistry('FileSystemRegistry')
-        $fileSystemRegistry.AddFavoriteFolder($Path, $Icon, $Name, $Description, $Preview)
+        $fileSystemRegistry.AddFavoriteFolder($Path, $Icon, $Name, $Description, $Preview, $EntryGroup)
     }
 }

--- a/module/PowerShellRun/Public/Add-PSRunFavoriteFolder.ps1
+++ b/module/PowerShellRun/Public/Add-PSRunFavoriteFolder.ps1
@@ -20,6 +20,9 @@ The description string. The folder path is used by default.
 .PARAMETER Preview
 The custom preview string.
 
+.PARAMETER EntryGroup
+The parent entry group object where this new entry is added.
+
 .INPUTS
 None.
 

--- a/module/PowerShellRun/Public/Add-PSRunScriptBlock.ps1
+++ b/module/PowerShellRun/Public/Add-PSRunScriptBlock.ps1
@@ -50,11 +50,14 @@ function Add-PSRunScriptBlock {
         [String]$Description,
 
         [Parameter(ValueFromPipelineByPropertyName = $true)]
-        [String[]]$Preview
+        [String[]]$Preview,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [Object]$EntryGroup
     )
 
     process {
         $registry = $script:globalStore.GetRegistry('ScriptRegistry')
-        $registry.AddScriptBlock($ScriptBlock, $Icon, $Name, $Description, $Preview)
+        $registry.AddScriptBlock($ScriptBlock, $Icon, $Name, $Description, $Preview, $EntryGroup)
     }
 }

--- a/module/PowerShellRun/Public/Add-PSRunScriptBlock.ps1
+++ b/module/PowerShellRun/Public/Add-PSRunScriptBlock.ps1
@@ -20,6 +20,9 @@ The description string.
 .PARAMETER Preview
 The custom preview string. The definition of the ScriptBlock is used by default.
 
+.PARAMETER EntryGroup
+The parent entry group object where this new entry is added.
+
 .INPUTS
 None.
 

--- a/module/PowerShellRun/Public/Add-PSRunScriptFile.ps1
+++ b/module/PowerShellRun/Public/Add-PSRunScriptFile.ps1
@@ -48,11 +48,14 @@ function Add-PSRunScriptFile {
         [String]$Description,
 
         [Parameter(ValueFromPipelineByPropertyName = $true)]
-        [String[]]$Preview
+        [String[]]$Preview,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [Object]$EntryGroup
     )
 
     process {
         $registry = $script:globalStore.GetRegistry('ScriptRegistry')
-        $registry.AddScriptFile($Path, $Icon, $Name, $Description, $Preview)
+        $registry.AddScriptFile($Path, $Icon, $Name, $Description, $Preview, $EntryGroup)
     }
 }

--- a/module/PowerShellRun/Public/Add-PSRunScriptFile.ps1
+++ b/module/PowerShellRun/Public/Add-PSRunScriptFile.ps1
@@ -20,6 +20,9 @@ The description string. The filepath is used by default.
 .PARAMETER Preview
 The custom preview string. The content of the script file is used by default.
 
+.PARAMETER EntryGroup
+The parent entry group object where this new entry is added.
+
 .INPUTS
 None.
 

--- a/module/PowerShellRun/Public/Enable-PSRunEntry.ps1
+++ b/module/PowerShellRun/Public/Enable-PSRunEntry.ps1
@@ -24,12 +24,12 @@ Enable-PSRunEntry -Category Application, Function, Utility
 function Enable-PSRunEntry {
     [CmdletBinding()]
     param (
-        [ValidateSet('All', 'Application', 'Executable', 'Function', 'Utility', 'Favorite', 'Script')]
+        [ValidateSet('All', 'Application', 'Executable', 'Function', 'Utility', 'Favorite', 'Script', 'EntryGroup')]
         [String[]]$Category = 'All'
     )
 
     if ($Category -contains 'All') {
-        $Category = 'Application', 'Executable', 'Function', 'Utility', 'Favorite', 'Script'
+        $Category = 'Application', 'Executable', 'Function', 'Utility', 'Favorite', 'Script', 'EntryGroup'
     }
     $script:globalStore.EnableEntries($Category)
 }

--- a/module/PowerShellRun/Public/Enable-PSRunEntry.ps1
+++ b/module/PowerShellRun/Public/Enable-PSRunEntry.ps1
@@ -31,5 +31,5 @@ function Enable-PSRunEntry {
     if ($Category -contains 'All') {
         $Category = $script:globalStore.allCategoryNames
     }
-    $script:globalStore.EnableEntries($Category)
+    $script:globalStore.InitializeEntries($Category)
 }

--- a/module/PowerShellRun/Public/Enable-PSRunEntry.ps1
+++ b/module/PowerShellRun/Public/Enable-PSRunEntry.ps1
@@ -28,6 +28,11 @@ function Enable-PSRunEntry {
         [String[]]$Category = 'All'
     )
 
+    if ($script:globalStore.IsEntriesInitialized()) {
+        Write-Error -Message 'Entries already initialized. This function must be called only once.' -Category InvalidOperation
+        return
+    }
+
     if ($Category -contains 'All') {
         $Category = $script:globalStore.allCategoryNames
     }

--- a/module/PowerShellRun/Public/Enable-PSRunEntry.ps1
+++ b/module/PowerShellRun/Public/Enable-PSRunEntry.ps1
@@ -29,7 +29,7 @@ function Enable-PSRunEntry {
     )
 
     if ($Category -contains 'All') {
-        $Category = 'Application', 'Executable', 'Function', 'Utility', 'Favorite', 'Script', 'EntryGroup'
+        $Category = $script:globalStore.allCategoryNames
     }
     $script:globalStore.EnableEntries($Category)
 }

--- a/tests/Public/Add-PSRunEntryGroup.Tests.ps1
+++ b/tests/Public/Add-PSRunEntryGroup.Tests.ps1
@@ -1,0 +1,54 @@
+﻿Describe 'Add-PSRunEntryGroup' {
+    BeforeEach {
+        Import-Module $PSScriptRoot/../../module/PowerShellRun -Force
+    }
+
+    It 'should add a normal entry group' {
+        Enable-PSRunEntry -Category EntryGroup
+        Add-PSRunEntryGroup -Icon '😆' -Name 'Custom Name' -Description 'Custom Desc' -Preview 'Custom Preview'
+        InModuleScope 'PowerShellRun' {
+            $registry = $script:globalStore.GetRegistry('EntryGroupRegistry')
+            $registry.entries.Count | Should -Be 1
+        }
+    }
+
+    It 'should add a category entry group' {
+        Enable-PSRunEntry -Category EntryGroup
+        Add-PSRunEntryGroup -Icon '😆' -Name 'Custom Name' -Description 'Custom Desc' -Preview 'Custom Preview' -Category Function
+        InModuleScope 'PowerShellRun' {
+            $registry = $script:globalStore.GetRegistry('EntryGroupRegistry')
+            $registry.entries.Count | Should -Be 1
+        }
+    }
+
+    It 'should add the entry under an entry group' {
+        Enable-PSRunEntry -Category EntryGroup
+        $parentGroup = Add-PSRunEntryGroup -Name 'Parent Group' -PassThru
+        Add-PSRunEntryGroup -Name 'Custom Name' -EntryGroup $parentGroup
+
+        $parentGroup.DirectChildEntries.Count | Should -Be 1
+        InModuleScope 'PowerShellRun' {
+            $registry = $script:globalStore.GetRegistry('EntryGroupRegistry')
+            $registry.entries.Count | Should -Be 1
+        }
+    }
+
+    It 'should not add an entry if category is disabled' {
+        Enable-PSRunEntry -Category Function
+        Add-PSRunEntryGroup -Icon '😆' -Name 'Custom Name' -Description 'Custom Desc' -Preview 'Custom Preview'
+        InModuleScope 'PowerShellRun' {
+            $registry = $script:globalStore.GetRegistry('EntryGroupRegistry')
+            $registry.entries.Count | Should -Be 0
+        }
+    }
+
+    It 'should return the entry group with PassThru' {
+        Enable-PSRunEntry -Category EntryGroup
+        $group = Add-PSRunEntryGroup -Name 'Custom Name' -PassThru
+        $group | Should -Not -BeNullOrEmpty
+    }
+
+    AfterEach {
+        Remove-Module PowerShellRun -Force
+    }
+}

--- a/tests/Public/Add-PSRunFavoriteFile.Tests.ps1
+++ b/tests/Public/Add-PSRunFavoriteFile.Tests.ps1
@@ -4,10 +4,20 @@
     }
 
     It 'should add an entry' {
+        Enable-PSRunEntry -Category Favorite
         Add-PSRunFavoriteFile -Path 'C:/folder/test.txt' -Icon '😆' -Name 'Custom Name' -Description 'Custom Desc' -Preview 'Custom Preview'
         InModuleScope 'PowerShellRun' {
-            $fileSystemRegistry = $script:globalStore.GetRegistry('FileSystemRegistry')
-            $fileSystemRegistry.favoritesEntries.Count | Should -Be 1
+            $registry = $script:globalStore.GetRegistry('FileSystemRegistry')
+            $registry.favoritesEntries.Count | Should -Be 1
+        }
+    }
+
+    It 'should not add an entry if category is disabled' {
+        Enable-PSRunEntry -Category Function
+        Add-PSRunFavoriteFile -Path 'C:/folder/test.txt' -Icon '😆' -Name 'Custom Name' -Description 'Custom Desc' -Preview 'Custom Preview'
+        InModuleScope 'PowerShellRun' {
+            $registry = $script:globalStore.GetRegistry('FileSystemRegistry')
+            $registry.favoritesEntries.Count | Should -Be 0
         }
     }
 

--- a/tests/Public/Add-PSRunFavoriteFile.Tests.ps1
+++ b/tests/Public/Add-PSRunFavoriteFile.Tests.ps1
@@ -12,6 +12,14 @@
         }
     }
 
+    It 'should add the entry under an entry group' {
+        Enable-PSRunEntry -Category Favorite, EntryGroup
+        $parentGroup = Add-PSRunEntryGroup -Name 'Parent Group' -PassThru
+        Add-PSRunFavoriteFile -Path 'C:/folder/test.txt' -EntryGroup $parentGroup
+
+        $parentGroup.DirectChildEntries.Count | Should -Be 1
+    }
+
     It 'should not add an entry if category is disabled' {
         Enable-PSRunEntry -Category Function
         Add-PSRunFavoriteFile -Path 'C:/folder/test.txt' -Icon '😆' -Name 'Custom Name' -Description 'Custom Desc' -Preview 'Custom Preview'

--- a/tests/Public/Add-PSRunFavoriteFolder.Tests.ps1
+++ b/tests/Public/Add-PSRunFavoriteFolder.Tests.ps1
@@ -12,6 +12,14 @@
         }
     }
 
+    It 'should add the entry under an entry group' {
+        Enable-PSRunEntry -Category Favorite, EntryGroup
+        $parentGroup = Add-PSRunEntryGroup -Name 'Parent Group' -PassThru
+        Add-PSRunFavoriteFolder -Path 'C:/folder' -EntryGroup $parentGroup
+
+        $parentGroup.DirectChildEntries.Count | Should -Be 1
+    }
+
     It 'should not add an entry if category is disabled' {
         Enable-PSRunEntry -Category Function
         Add-PSRunFavoriteFolder -Path 'C:/folder' -Icon '😆' -Name 'Custom Name' -Description 'Custom Desc' -Preview 'Custom Preview'

--- a/tests/Public/Add-PSRunFavoriteFolder.Tests.ps1
+++ b/tests/Public/Add-PSRunFavoriteFolder.Tests.ps1
@@ -4,10 +4,20 @@
     }
 
     It 'should add an entry' {
+        Enable-PSRunEntry -Category Favorite
         Add-PSRunFavoriteFolder -Path 'C:/folder' -Icon '😆' -Name 'Custom Name' -Description 'Custom Desc' -Preview 'Custom Preview'
         InModuleScope 'PowerShellRun' {
-            $fileSystemRegistry = $script:globalStore.GetRegistry('FileSystemRegistry')
-            $fileSystemRegistry.favoritesEntries.Count | Should -Be 1
+            $registry = $script:globalStore.GetRegistry('FileSystemRegistry')
+            $registry.favoritesEntries.Count | Should -Be 1
+        }
+    }
+
+    It 'should not add an entry if category is disabled' {
+        Enable-PSRunEntry -Category Function
+        Add-PSRunFavoriteFolder -Path 'C:/folder' -Icon '😆' -Name 'Custom Name' -Description 'Custom Desc' -Preview 'Custom Preview'
+        InModuleScope 'PowerShellRun' {
+            $registry = $script:globalStore.GetRegistry('FileSystemRegistry')
+            $registry.favoritesEntries.Count | Should -Be 0
         }
     }
 

--- a/tests/Public/Add-PSRunScriptBlock.Tests.ps1
+++ b/tests/Public/Add-PSRunScriptBlock.Tests.ps1
@@ -4,10 +4,20 @@
     }
 
     It 'should add an entry' {
+        Enable-PSRunEntry -Category Script
         Add-PSRunScriptBlock -ScriptBlock { 'hello' } -Icon '😆' -Name 'Custom Name' -Description 'Custom Desc' -Preview 'Custom Preview'
         InModuleScope 'PowerShellRun' {
             $registry = $script:globalStore.GetRegistry('ScriptRegistry')
             $registry.entries.Count | Should -Be 1
+        }
+    }
+
+    It 'should not add an entry if category is disabled' {
+        Enable-PSRunEntry -Category Function
+        Add-PSRunScriptBlock -ScriptBlock { 'hello' } -Icon '😆' -Name 'Custom Name' -Description 'Custom Desc' -Preview 'Custom Preview'
+        InModuleScope 'PowerShellRun' {
+            $registry = $script:globalStore.GetRegistry('ScriptRegistry')
+            $registry.entries.Count | Should -Be 0
         }
     }
 

--- a/tests/Public/Add-PSRunScriptBlock.Tests.ps1
+++ b/tests/Public/Add-PSRunScriptBlock.Tests.ps1
@@ -12,6 +12,14 @@
         }
     }
 
+    It 'should add the entry under an entry group' {
+        Enable-PSRunEntry -Category Script, EntryGroup
+        $parentGroup = Add-PSRunEntryGroup -Name 'Parent Group' -PassThru
+        Add-PSRunScriptBlock -ScriptBlock { 'hello' } -Name 'Custom Name' -EntryGroup $parentGroup
+
+        $parentGroup.DirectChildEntries.Count | Should -Be 1
+    }
+
     It 'should not add an entry if category is disabled' {
         Enable-PSRunEntry -Category Function
         Add-PSRunScriptBlock -ScriptBlock { 'hello' } -Icon '😆' -Name 'Custom Name' -Description 'Custom Desc' -Preview 'Custom Preview'

--- a/tests/Public/Add-PSRunScriptFile.Tests.ps1
+++ b/tests/Public/Add-PSRunScriptFile.Tests.ps1
@@ -12,6 +12,14 @@
         }
     }
 
+    It 'should add the entry under an entry group' {
+        Enable-PSRunEntry -Category Script, EntryGroup
+        $parentGroup = Add-PSRunEntryGroup -Name 'Parent Group' -PassThru
+        Add-PSRunScriptFile -Path 'D:/test.ps1' -EntryGroup $parentGroup
+
+        $parentGroup.DirectChildEntries.Count | Should -Be 1
+    }
+
     It 'should not add an entry if category is disabled' {
         Enable-PSRunEntry -Category Function
         Add-PSRunScriptFile -Path 'D:/test.ps1' -Icon '😆' -Name 'Custom Name' -Description 'Custom Desc' -Preview 'Custom Preview'

--- a/tests/Public/Add-PSRunScriptFile.Tests.ps1
+++ b/tests/Public/Add-PSRunScriptFile.Tests.ps1
@@ -4,10 +4,20 @@
     }
 
     It 'should add an entry' {
+        Enable-PSRunEntry -Category Script
         Add-PSRunScriptFile -Path 'D:/test.ps1' -Icon '😆' -Name 'Custom Name' -Description 'Custom Desc' -Preview 'Custom Preview'
         InModuleScope 'PowerShellRun' {
             $registry = $script:globalStore.GetRegistry('ScriptRegistry')
             $registry.entries.Count | Should -Be 1
+        }
+    }
+
+    It 'should not add an entry if category is disabled' {
+        Enable-PSRunEntry -Category Function
+        Add-PSRunScriptFile -Path 'D:/test.ps1' -Icon '😆' -Name 'Custom Name' -Description 'Custom Desc' -Preview 'Custom Preview'
+        InModuleScope 'PowerShellRun' {
+            $registry = $script:globalStore.GetRegistry('ScriptRegistry')
+            $registry.entries.Count | Should -Be 0
         }
     }
 

--- a/tests/Public/Enable-PSRunEntry.Tests.ps1
+++ b/tests/Public/Enable-PSRunEntry.Tests.ps1
@@ -11,6 +11,12 @@
         Enable-PSRunEntry Function, Utility, Favorite
     }
 
+    It 'should throw if called twice' {
+        Enable-PSRunEntry
+        { Enable-PSRunEntry -ErrorAction Stop } | Should -Throw
+    }
+
+
     AfterEach {
         Remove-Module PowerShellRun -Force
     }

--- a/tests/Public/Stop-PSRunFunctionRegistration.Tests.ps1
+++ b/tests/Public/Stop-PSRunFunctionRegistration.Tests.ps1
@@ -8,13 +8,29 @@
     }
 
     It 'should register a function' {
+        Enable-PSRunEntry -Category Function
+
         Start-PSRunFunctionRegistration
         function global:Test {}
         Stop-PSRunFunctionRegistration
 
         InModuleScope 'PowerShellRun' {
-            $functionRegistry = $script:globalStore.GetRegistry('FunctionRegistry')
-            $functionRegistry.entries.Count | Should -Be 1
+            $registry = $script:globalStore.GetRegistry('FunctionRegistry')
+            $registry.entries.Count | Should -Be 1
+        }
+        $function:Test = $null
+    }
+
+    It 'should not register a function if category is disabled' {
+        Enable-PSRunEntry -Category Script
+
+        Start-PSRunFunctionRegistration
+        function global:Test {}
+        Stop-PSRunFunctionRegistration
+
+        InModuleScope 'PowerShellRun' {
+            $registry = $script:globalStore.GetRegistry('FunctionRegistry')
+            $registry.entries.Count | Should -Be 0
         }
         $function:Test = $null
     }

--- a/tests/RestartableSession.ps1
+++ b/tests/RestartableSession.ps1
@@ -8,8 +8,7 @@ Enter-RSSession -OnStart {
 
     & $build Debug
     Import-Module "$root/module/PowerShellRun"
-    Enable-PSRunEntry -Category All
-    Set-PSRunPSReadLineKeyHandler -InvokePSRunChord 'Ctrl+Spacebar' -PSReadLineHistoryChord 'Ctrl+r'
+    Set-PSRunPSReadLineKeyHandler -InvokePsRunChord 'Ctrl+Spacebar' -PSReadLineHistoryChord 'Ctrl+r'
 
     function Restart {
         Restart-RSSession


### PR DESCRIPTION
This PR adds a new entry type `EntryGroup`. This feature was discussed and requested in #50.

Entries are created by `Add-PSRunEntryGroup` function, and other `Add-PSRun*` functions now take `-EntryGroup` parameter to specify the parent group.

```powershell
$projectA = Add-PSRunEntryGroup -Name 'ProjectA' -Icon '🍎' -PassThru
Add-PSRunScriptFile -Path 'Build.ps1' -Icon '🔁' -EntryGroup $projectA
Add-PSRunScriptBlock -Name 'Hello' -ScriptBlock { 'Hello from ProjectA' } -Icon '👋' -EntryGroup $projectA
```

![image](https://github.com/user-attachments/assets/66da8711-ee30-4dcb-874b-cf357cc619a9)

If you add `-Category` parameter to `Add-PSRunEntryGroup`, all the entries that belong to the specified categories are added as children of the group instead of being listed in the top menu.

```powershell
Add-PSRunEntryGroup -Name 'Apps' -Category Application, Executable
```

![image](https://github.com/user-attachments/assets/1eb5a8a6-1342-4d44-9804-55ee7dd2b1e6)
