### PR TITLE
Launch with arguments

### DIFF
--- a/module/PowerShellRun/Private/ApplicationRegistry.ps1
+++ b/module/PowerShellRun/Private/ApplicationRegistry.ps1
@@ -141,7 +141,6 @@ class ApplicationRegistry : EntryRegistry {
             if ($result.KeyCombination -eq $script:globalStore.firstActionKey) {
                 & $script:globalStore.invokeFile $fullName
             } elseif ($result.KeyCombination -eq $script:globalStore.thirdActionKey) {
-                $argumentList = $script:globalStore.GetArgumentListFor($name)
                 $argumentList, $keyCombination = $script:globalStore.GetArgumentListFor($name)
                 if ($keyCombination -eq 'Backspace') {
                     Restore-PSRunParentSelector
@@ -175,7 +174,8 @@ class ApplicationRegistry : EntryRegistry {
                         $entry.Icon = '🚀'
                         $entry.Name = [System.IO.Path]::GetFileNameWithoutExtension($app.BaseName)
                         $entry.Preview = $app.FullName
-                        $entry.ActionKeys = $actionKeys
+                        # Not sure how to pass aruments to apps so only supports Launch action key.
+                        $entry.ActionKeys = $actionKeys[0]
 
                         $entry.UserData = @{
                             ScriptBlock = $callback

--- a/module/PowerShellRun/Private/ApplicationRegistry.ps1
+++ b/module/PowerShellRun/Private/ApplicationRegistry.ps1
@@ -36,9 +36,11 @@ class ApplicationRegistry : EntryRegistry {
             } elseif ($result.KeyCombination -eq $script:globalStore.secondActionKey) {
                 Start-Process $path -Verb runAs
             } elseif ($result.KeyCombination -eq $script:globalStore.thirdActionKey) {
-                $argumentList = $script:globalStore.GetArgumentListFor($name)
-                if ($null -eq $argumentList) {
+                $argumentList, $keyCombination = $script:globalStore.GetArgumentListFor($name)
+                if ($keyCombination -eq 'Backspace') {
                     Restore-PSRunParentSelector
+                } elseif ($null -eq $argumentList) {
+                    return
                 } else {
                     & $script:globalStore.invokeFile $path $argumentList
                 }
@@ -140,8 +142,11 @@ class ApplicationRegistry : EntryRegistry {
                 & $script:globalStore.invokeFile $fullName
             } elseif ($result.KeyCombination -eq $script:globalStore.thirdActionKey) {
                 $argumentList = $script:globalStore.GetArgumentListFor($name)
-                if ($null -eq $argumentList) {
+                $argumentList, $keyCombination = $script:globalStore.GetArgumentListFor($name)
+                if ($keyCombination -eq 'Backspace') {
                     Restore-PSRunParentSelector
+                } elseif ($null -eq $argumentList) {
+                    return
                 } else {
                     & $script:globalStore.invokeFile $fullName $argumentList
                 }

--- a/module/PowerShellRun/Private/FunctionRegistry.ps1
+++ b/module/PowerShellRun/Private/FunctionRegistry.ps1
@@ -43,9 +43,11 @@ class FunctionRegistry : EntryRegistry {
                     $function.ScriptBlock.Ast.Body.ParamBlock.Parameters
                 }
 
-                $parameters = $script:globalStore.GetParameterList($astParameters)
-                if ($null -eq $parameters) {
+                $parameters, $keyCombination = $script:globalStore.GetParameterList($astParameters)
+                if ($keyCombination -eq 'Backspace') {
                     Restore-PSRunParentSelector
+                } elseif ($null -eq $parameters) {
+                    return
                 } else {
                     & $functionName @parameters
                 }

--- a/module/PowerShellRun/Private/ScriptRegistry.ps1
+++ b/module/PowerShellRun/Private/ScriptRegistry.ps1
@@ -27,6 +27,7 @@ class ScriptRegistry : EntryRegistry {
         $this.scriptBlockActionKeys = @(
             [PowerShellRun.ActionKey]::new($script:globalStore.firstActionKey, 'Invoke script')
             [PowerShellRun.ActionKey]::new($script:globalStore.secondActionKey, 'Get definition')
+            [PowerShellRun.ActionKey]::new($script:globalStore.thirdActionKey, 'Invoke with arguments')
             [PowerShellRun.ActionKey]::new($script:globalStore.copyActionKey, 'Copy definition to Clipboard')
         )
 
@@ -38,6 +39,14 @@ class ScriptRegistry : EntryRegistry {
                 & $scriptBlock
             } elseif ($result.KeyCombination -eq $script:globalStore.secondActionKey) {
                 $scriptBlock.ToString()
+            } elseif ($result.KeyCombination -eq $script:globalStore.thirdActionKey) {
+                $astParameters = $scriptBlock.Ast.ParamBlock.Parameters
+                $parameters = $script:globalStore.GetParameterList($astParameters)
+                if ($null -eq $parameters) {
+                    Restore-PSRunParentSelector
+                } else {
+                    & $scriptBlock @parameters
+                }
             } elseif ($result.KeyCombination -eq $script:globalStore.copyActionKey) {
                 $scriptBlock.ToString() | Set-Clipboard
             }

--- a/module/PowerShellRun/Private/ScriptRegistry.ps1
+++ b/module/PowerShellRun/Private/ScriptRegistry.ps1
@@ -41,9 +41,11 @@ class ScriptRegistry : EntryRegistry {
                 $scriptBlock.ToString()
             } elseif ($result.KeyCombination -eq $script:globalStore.thirdActionKey) {
                 $astParameters = $scriptBlock.Ast.ParamBlock.Parameters
-                $parameters = $script:globalStore.GetParameterList($astParameters)
-                if ($null -eq $parameters) {
+                $parameters, $keyCombination = $script:globalStore.GetParameterList($astParameters)
+                if ($keyCombination -eq 'Backspace') {
                     Restore-PSRunParentSelector
+                } elseif ($null -eq $parameters) {
+                    return
                 } else {
                     & $scriptBlock @parameters
                 }


### PR DESCRIPTION
This PR adds `Launch with arguments` action to applications, executables, script blocks and functions. It was discussed and requested in #52.

For applications and executables, a single prompt is shown and you can type the argument. The typed string is split by spaces and passed to the application as arguments.

For script blocks and functions, the prompt asks the input per parameter.

![LaunchWithArguments](https://github.com/user-attachments/assets/01c02cde-4bd5-4532-9215-1c114a94dc03)
