### PR TITLE
Support module reloading

### DIFF
--- a/module/PowerShellRun/PowerShellRun.psd1
+++ b/module/PowerShellRun/PowerShellRun.psd1
@@ -25,7 +25,7 @@
     Description = 'App, Utility and Function Launcher for PowerShell'
 
     # Minimum version of the PowerShell engine required by this module
-    PowerShellVersion = '7.2'
+    PowerShellVersion = '7.4'
 
     # Name of the PowerShell host required by this module
     # PowerShellHostName = ''

--- a/module/PowerShellRun/Private/ApplicationRegistry.ps1
+++ b/module/PowerShellRun/Private/ApplicationRegistry.ps1
@@ -1,4 +1,6 @@
 using module ./_EntryRegistry.psm1
+
+[NoRunspaceAffinity()]
 class ApplicationRegistry : EntryRegistry {
     $sync = [System.Collections.Hashtable]::Synchronized(@{})
     $registerEntryJob = $null

--- a/module/PowerShellRun/Private/EntryGroupRegistry.ps1
+++ b/module/PowerShellRun/Private/EntryGroupRegistry.ps1
@@ -1,6 +1,7 @@
 using module ./_EntryGroup.psm1
 using module ./_EntryRegistry.psm1
 
+[NoRunspaceAffinity()]
 class EntryGroupRegistry : EntryRegistry {
     $entries = [System.Collections.Generic.List[PowerShellRun.SelectorEntry]]::new()
     $normalGroups = [System.Collections.Generic.List[EntryGroup]]::new()

--- a/module/PowerShellRun/Private/FileSystemRegistry.ps1
+++ b/module/PowerShellRun/Private/FileSystemRegistry.ps1
@@ -1,6 +1,7 @@
 using module ./_EntryGroup.psm1
 using module ./_EntryRegistry.psm1
 
+[NoRunspaceAffinity()]
 class FileSystemRegistry : EntryRegistry {
     $favoritesEntries = [System.Collections.Generic.List[PowerShellRun.SelectorEntry]]::new()
     $fileManagerEntry = [System.Collections.Generic.List[PowerShellRun.SelectorEntry]]::new()

--- a/module/PowerShellRun/Private/FunctionRegistry.ps1
+++ b/module/PowerShellRun/Private/FunctionRegistry.ps1
@@ -63,7 +63,12 @@ class FunctionRegistry : EntryRegistry {
             Write-Error -Message 'Function registration already started.' -Category InvalidOperation -ErrorAction $errorAction
             return
         }
-        $this.functionsAtRegisterStart = (Get-Command -Type Function).Name
+
+        $this.functionsAtRegisterStart = @{}
+        $functions = Get-Command -Type Function -ListImported
+        $functions | ForEach-Object {
+            $this.functionsAtRegisterStart[$_.Name] = $_.ScriptBlock
+        }
     }
 
     [void] StopRegistration($errorAction) {
@@ -76,9 +81,10 @@ class FunctionRegistry : EntryRegistry {
             return
         }
 
-        $functionsAtStop = Get-Command -Type Function
+        $functionsAtStop = Get-Command -Type Function -ListImported
         foreach ($function in $functionsAtStop) {
-            if ($function.Name -in $this.functionsAtRegisterStart) {
+            $functionAtStart = $this.functionsAtRegisterStart[$function.Name]
+            if ($functionAtStart -eq $function.ScriptBlock) {
                 continue
             }
             $this.isEntryUpdated = $true

--- a/module/PowerShellRun/Private/FunctionRegistry.ps1
+++ b/module/PowerShellRun/Private/FunctionRegistry.ps1
@@ -1,4 +1,6 @@
 using module ./_EntryRegistry.psm1
+
+[NoRunspaceAffinity()]
 class FunctionRegistry : EntryRegistry {
     $functionsAtRegisterStart = $null
     $entries = [System.Collections.Generic.List[PowerShellRun.SelectorEntry]]::new()

--- a/module/PowerShellRun/Private/GlobalStore.ps1
+++ b/module/PowerShellRun/Private/GlobalStore.ps1
@@ -1,6 +1,7 @@
 using module ./_EntryRegistry.psm1
 using module ./_EntryGroup.psm1
 
+[NoRunspaceAffinity()]
 class GlobalStore {
     $entries = [System.Collections.Generic.List[PowerShellRun.SelectorEntry]]::new()
     $isEntryInitialized = $false

--- a/module/PowerShellRun/Private/ScriptRegistry.ps1
+++ b/module/PowerShellRun/Private/ScriptRegistry.ps1
@@ -1,6 +1,7 @@
 using module ./_EntryGroup.psm1
 using module ./_EntryRegistry.psm1
 
+[NoRunspaceAffinity()]
 class ScriptRegistry : EntryRegistry {
     $entries = [System.Collections.Generic.List[PowerShellRun.SelectorEntry]]::new()
     $isEntryUpdated = $false

--- a/module/PowerShellRun/Private/WinGetRegistry.ps1
+++ b/module/PowerShellRun/Private/WinGetRegistry.ps1
@@ -1,4 +1,6 @@
 using module ./_EntryRegistry.psm1
+
+[NoRunspaceAffinity()]
 class WinGetRegistry : EntryRegistry {
     $entries = [System.Collections.Generic.List[PowerShellRun.SelectorEntry]]::new()
     $subMenuEntries = [System.Collections.Generic.List[PowerShellRun.SelectorEntry]]::new()

--- a/module/PowerShellRun/Private/_EntryGroup.psm1
+++ b/module/PowerShellRun/Private/_EntryGroup.psm1
@@ -1,3 +1,4 @@
+[NoRunspaceAffinity()]
 class EntryGroup {
     [Object]$Registry
     [String]$Name

--- a/module/PowerShellRun/Private/_EntryRegistry.psm1
+++ b/module/PowerShellRun/Private/_EntryRegistry.psm1
@@ -1,3 +1,4 @@
+[NoRunspaceAffinity()]
 class EntryRegistry {
     [System.Collections.Generic.List[PowerShellRun.SelectorEntry]] GetEntries([String[]]$categories) {
         Write-Error -Message 'This method needs to be overridden.' -Category NotImplemented

--- a/tests/Public/Stop-PSRunFunctionRegistration.Tests.ps1
+++ b/tests/Public/Stop-PSRunFunctionRegistration.Tests.ps1
@@ -21,6 +21,21 @@
         $function:Test = $null
     }
 
+    It 'should register a redefined function' {
+        Enable-PSRunEntry -Category Function
+
+        function global:Test {}
+        Start-PSRunFunctionRegistration
+        function global:Test {}
+        Stop-PSRunFunctionRegistration
+
+        InModuleScope 'PowerShellRun' {
+            $registry = $script:globalStore.GetRegistry('FunctionRegistry')
+            $registry.entries.Count | Should -Be 1
+        }
+        $function:Test = $null
+    }
+
     It 'should not register a function if category is disabled' {
         Enable-PSRunEntry -Category Script
 


### PR DESCRIPTION
This PR fixes #62.

- `Start/Stop-PSRunFunctionRegistration` was not able to detect functions that already existed and redefined between them. The code in this PR checks the ScriptBlock difference and solves the issue.
- When PowerShellRun is reloaded by `Import-Module -Force`, internal classes are not reloaded and class methods are bound to the removed old module. That was causing multiple issues so added `NoRunspaceAffinity` to all the classes.
- Minimum PowerShell version changes to 7.4 because of `NoRunspaceAffinity`.