### PR TITLE
Use PSRun's SelectorOption consistently in nested menus

### DIFF
--- a/module/PowerShellRun/Private/EntryGroupRegistry.ps1
+++ b/module/PowerShellRun/Private/EntryGroupRegistry.ps1
@@ -56,7 +56,7 @@ class EntryGroupRegistry : EntryRegistry {
             }
 
             if ($result.KeyCombination -eq $script:globalStore.firstActionKey) {
-                $option = $script:globalStore.psRunSelectorOption.DeepClone()
+                $option = $script:globalStore.GetPSRunSelectorOption()
                 $option.QuitWithBackspaceOnEmptyQuery = $true
                 $option.Prompt = "$($group.Name)> "
                 $prevContext = $null

--- a/module/PowerShellRun/Private/FileSystemRegistry.ps1
+++ b/module/PowerShellRun/Private/FileSystemRegistry.ps1
@@ -192,7 +192,7 @@ class FileSystemRegistry : EntryRegistry {
     $fileManagerLoop = {
         param($rootDir, $arguments)
 
-        $option = $script:globalStore.psRunSelectorOption.DeepClone()
+        $option = $script:globalStore.GetPSRunSelectorOption()
         $option.QuitWithBackspaceOnEmptyQuery = $true
 
         $distance = 0

--- a/module/PowerShellRun/Private/GlobalStore.ps1
+++ b/module/PowerShellRun/Private/GlobalStore.ps1
@@ -106,6 +106,10 @@ class GlobalStore {
         $psRunKeyBinding.DefaultActionKeys[0].Description = 'Quit'
     }
 
+    [PowerShellRun.SelectorOption] GetPSRunSelectorOption() {
+        return $this.psRunSelectorOption.DeepClone()
+    }
+
     [EntryRegistry] GetRegistry($typeName) {
         foreach ($registry in $this.registries) {
             if ($registry.GetType().Name -eq $typeName) {
@@ -283,7 +287,7 @@ class GlobalStore {
     }
 
     [Object[]] GetArgumentListFor([String]$name) {
-        $option = Get-PSRunDefaultSelectorOption
+        $option = $this.GetPSRunSelectorOption()
         $option.Prompt = 'Type arguments for {0}> ' -f $name
         $option.QuitWithBackspaceOnEmptyQuery = $true
         $promptResult = Invoke-PSRunPrompt -Option $option
@@ -326,7 +330,7 @@ class GlobalStore {
             return @{}, $null
         }
 
-        $option = Get-PSRunDefaultSelectorOption
+        $option = $this.GetPSRunSelectorOption()
         $option.QuitWithBackspaceOnEmptyQuery = $true
 
         $parameters = @{}

--- a/module/PowerShellRun/Private/WinGetRegistry.ps1
+++ b/module/PowerShellRun/Private/WinGetRegistry.ps1
@@ -43,7 +43,7 @@ class WinGetRegistry : EntryRegistry {
         $callback = {
             $thisClass = $args[0].ArgumentList
 
-            $option = Get-PSRunDefaultSelectorOption
+            $option = $script:globalStore.GetPSRunSelectorOption()
             $option.Prompt = 'WinGet (PSRun) > '
             $option.QuitWithBackspaceOnEmptyQuery = $true
 
@@ -119,7 +119,7 @@ class WinGetRegistry : EntryRegistry {
         $callback = {
             param ($thisClass)
 
-            $option = Get-PSRunDefaultSelectorOption
+            $option = $script:globalStore.GetPSRunSelectorOption()
             $option.QuitWithBackspaceOnEmptyQuery = $true
             $promptContext = $null
 
@@ -220,7 +220,7 @@ class WinGetRegistry : EntryRegistry {
         $callback = {
             param ($thisClass)
 
-            $option = Get-PSRunDefaultSelectorOption
+            $option = $script:globalStore.GetPSRunSelectorOption()
             $option.QuitWithBackspaceOnEmptyQuery = $true
 
             $packages = Get-WinGetPackage | Where-Object { $_.IsUpdateAvailable }
@@ -295,7 +295,7 @@ class WinGetRegistry : EntryRegistry {
         $callback = {
             param ($thisClass)
 
-            $option = Get-PSRunDefaultSelectorOption
+            $option = $script:globalStore.GetPSRunSelectorOption()
             $option.QuitWithBackspaceOnEmptyQuery = $true
 
             $packages = Get-WinGetPackage


### PR DESCRIPTION
`Invoke-PSRun` uses the SelectorOption that overwrites `DefaultActionKeys` of the one set by `Set-PSRunDefaultSelectorOption`. However, some nested menus such as EntryGroup, File Manager and WinGet used the default SelectorOption as is. This PR fixes it so that nested menus consistently use the PSRun's option.