### PR TITLE
Add PromptSymbol to Theme

### DIFF
--- a/module/PowerShellRun/Private/EntryGroupRegistry.ps1
+++ b/module/PowerShellRun/Private/EntryGroupRegistry.ps1
@@ -58,7 +58,7 @@ class EntryGroupRegistry : EntryRegistry {
             if ($result.KeyCombination -eq $script:globalStore.firstActionKey) {
                 $option = $script:globalStore.GetPSRunSelectorOption()
                 $option.QuitWithBackspaceOnEmptyQuery = $true
-                $option.Prompt = "$($group.Name)> "
+                $option.Prompt = "$($group.Name)"
                 $prevContext = $null
 
                 while ($true) {

--- a/module/PowerShellRun/Private/FileSystemRegistry.ps1
+++ b/module/PowerShellRun/Private/FileSystemRegistry.ps1
@@ -203,7 +203,7 @@ class FileSystemRegistry : EntryRegistry {
             prevDir = $null
         }
         while ($true) {
-            $option.Prompt = "($distance) $($currentDir.path)> "
+            $option.Prompt = "($distance) $($currentDir.path)"
 
             $entries = [System.Collections.Generic.List[PowerShellRun.SelectorEntry]]::new()
             $addEntry = {

--- a/module/PowerShellRun/Private/GlobalStore.ps1
+++ b/module/PowerShellRun/Private/GlobalStore.ps1
@@ -275,7 +275,7 @@ class GlobalStore {
 
     [Object[]] GetArgumentListFor([String]$name) {
         $option = $this.GetPSRunSelectorOption()
-        $option.Prompt = 'Type arguments for {0}> ' -f $name
+        $option.Prompt = 'Type arguments for {0}' -f $name
         $option.QuitWithBackspaceOnEmptyQuery = $true
         $promptResult = Invoke-PSRunPrompt -Option $option
 
@@ -324,7 +324,7 @@ class GlobalStore {
         $promptContexts = @{}
         for ($i = 0; $i -lt $astParameters.Count; ) {
             $parameterName = $astParameters[$i].Name.VariablePath.UserPath.Replace('$', '')
-            $option.Prompt = '{0}> ' -f $parameterName
+            $option.Prompt = $parameterName
             $promptContext = $promptContexts[$parameterName]
             $promptResult = Invoke-PSRunPrompt -Option $option -Context $promptContext
 

--- a/module/PowerShellRun/Private/WinGetRegistry.ps1
+++ b/module/PowerShellRun/Private/WinGetRegistry.ps1
@@ -43,7 +43,7 @@ class WinGetRegistry : EntryRegistry {
             $thisClass = $args[0].ArgumentList
 
             $option = $script:globalStore.GetPSRunSelectorOption()
-            $option.Prompt = 'WinGet (PSRun) > '
+            $option.Prompt = 'WinGet (PSRun)'
             $option.QuitWithBackspaceOnEmptyQuery = $true
 
             $context = $null
@@ -115,9 +115,10 @@ class WinGetRegistry : EntryRegistry {
             $option = $script:globalStore.GetPSRunSelectorOption()
             $option.QuitWithBackspaceOnEmptyQuery = $true
             $promptContext = $null
+            $originalPrompt = $option.Prompt
 
             while ($true) {
-                $option.Prompt = 'Type application name to search > '
+                $option.Prompt = 'Type application name to search'
                 $promptResult = Invoke-PSRunPrompt -Option $option -Context $promptContext
                 $promptContext = $promptResult.Context
 
@@ -125,7 +126,7 @@ class WinGetRegistry : EntryRegistry {
                     return
                 }
 
-                $option.Prompt = '> '
+                $option.Prompt = $originalPrompt
                 $packages = Find-WinGetPackage -Query $promptResult.Input
                 if (-not $packages) {
                     Write-Warning -Message ('[{0}] No available application found.' -f $promptResult.Input)

--- a/module/PowerShellRun/Public/Invoke-PSRunPrompt.ps1
+++ b/module/PowerShellRun/Public/Invoke-PSRunPrompt.ps1
@@ -24,7 +24,7 @@ $result = Invoke-PSRunPrompt
 
 .EXAMPLE
 $option = Get-PSRunDefaultSelectorOption
-$option.Prompt = 'Type your name: '
+$option.Prompt = 'Type your name'
 $result = Invoke-PSRunPrompt -Option $option
 #>
 function Invoke-PSRunPrompt {

--- a/src/PowerShellRun/Application/SearchBar.cs
+++ b/src/PowerShellRun/Application/SearchBar.cs
@@ -39,11 +39,16 @@ internal class SearchBar
         borderHeight += theme.SearchBarBorderFlags.HasFlag(BorderFlag.Bottom) ? 1 : 0;
         RootLayout.LayoutSizeHeight.Set(LayoutSizeType.Absolute, 1 + borderHeight);
 
-        int promptLength = TextBox.GetDisplayWidth(promptString);
+        string promptLine = theme.PromptSymbol;
+        if (!string.IsNullOrEmpty(promptString))
+        {
+            promptLine = promptString + theme.PromptSymbol;
+        }
+        int promptLength = TextBox.GetDisplayWidth(promptLine);
         _prompt.OnlyStoreLinesInVisibleRange = false;
         _prompt.LayoutSizeWidth.Set(LayoutSizeType.Absolute, promptLength);
         _prompt.ClearAndSetFocusLine(0, 1);
-        _prompt.AddWord(0, promptString, theme.PromptForegroundColor, theme.PromptBackgroundColor);
+        _prompt.AddWord(0, promptLine, theme.PromptForegroundColor, theme.PromptBackgroundColor);
 
         if (theme.QueryBoxBackgroundColor is not null)
         {

--- a/src/PowerShellRun/Application/SelectorOption.cs
+++ b/src/PowerShellRun/Application/SelectorOption.cs
@@ -4,7 +4,7 @@ public class SelectorOption
 {
     public KeyBinding KeyBinding { get; set; } = new KeyBinding();
     public Theme Theme { get; set; } = new Theme();
-    public string Prompt { get; set; } = "> ";
+    public string Prompt { get; set; } = "";
     public bool EntryCycleScrollEnable { get; set; } = true;
     public bool PreviewCycleScrollEnable { get; set; } = false;
     public bool ActionWindowCycleScrollEnable { get; set; } = false;

--- a/src/PowerShellRun/Application/Theme.cs
+++ b/src/PowerShellRun/Application/Theme.cs
@@ -24,6 +24,7 @@ public class Theme
 
     public string Marker { get; set; } = "✓ ";
 
+    public string PromptSymbol { get; set; } = "> ";
     public FontColor? PromptForegroundColor { get; set; } = FontColor.Magenta;
     public FontColor? PromptBackgroundColor { get; set; } = null;
     public FontColor? QueryForegroundColor { get; set; } = null;


### PR DESCRIPTION
> [!WARNING]
> This is small but a breaking change

This PR adds `PromptSymbol` property to `Theme` and moves the default prompt "> " from `$option.Prompt` to `$option.Theme.PromptSymbol`.

Previously, even if an user customizes the prompt character, the prompt is reset by nested menus like the File Manager.

```powershell
$option = Get-PSRunDefaultSelectorOption
$option.Prompt = '👉 '
Set-PSRunDefaultSelectorOption $option
```

![image](https://github.com/user-attachments/assets/916d7917-dbbb-4a48-9b79-dfe495bbc910)

![image](https://github.com/user-attachments/assets/4ff8a777-d4f7-43d6-aa38-00fd59c9dee0)

By separating the `PromptSymbol` setting, it can keep the symbol in the nested menus.

![image](https://github.com/user-attachments/assets/f05e9714-924e-42d0-81ce-8ebf76282627)

This kind of advanced setting becomes possible too.

```powershell
$option.Theme.PromptForegroundColor = [PowerShellRun.FontColor]::White
$option.Theme.PromptBackgroundColor = [PowerShellRun.FontColor]::Magenta
$option.Theme.PromptSymbol = "$($PSStyle.Foreground.Magenta)$($PSStyle.Background.Black) $($PSStyle.Reset)"
$option.Prompt = 'Filter'
```

![image](https://github.com/user-attachments/assets/604e50be-e0c9-4a4b-9773-9b84f4a82065)

![image](https://github.com/user-attachments/assets/a9ca225b-fe04-4572-a27b-06afed94d8d0)

