### PR TITLE
Add conversion from string to FontColor

### DIFF
--- a/src/PowerShellRun/UI/FontColor.cs
+++ b/src/PowerShellRun/UI/FontColor.cs
@@ -11,11 +11,62 @@ public class FontColor : DeepCloneable
     private FontColor()
     {
     }
-    private FontColor(PresetId presetId, string foregroundEscapeCode, string backgroundEscapeCode)
+    private FontColor(PresetId presetId)
+    {
+        SetPresetId(presetId);
+    }
+    public FontColor(string str)
+    {
+        try
+        {
+            var presetId = Enum.Parse<PresetId>(str, true);
+            SetPresetId(presetId);
+        }
+        catch
+        {
+            bool success = SetHex(str);
+            if (!success)
+            {
+                throw new ArgumentException("Invalid string format. The string must be a preset name or a hex string.");
+            }
+        }
+    }
+
+    private void SetPresetId(PresetId presetId)
     {
         _presetId = presetId;
-        ForegroundEscapeCode = foregroundEscapeCode;
-        BackgroundEscapeCode = backgroundEscapeCode;
+        ForegroundEscapeCode = _presetEscapeSequenceTable[(int)presetId].ForegroundEscapeCode;
+        BackgroundEscapeCode = _presetEscapeSequenceTable[(int)presetId].BackgroundEscapeCode;
+    }
+
+    private bool SetHex(string hexString)
+    {
+        int r = 0;
+        int g = 0;
+        int b = 0;
+
+        if (!string.IsNullOrEmpty(hexString) && hexString.Length >= 6)
+        {
+            try
+            {
+                r = Convert.ToInt32(hexString.Substring(1, 2), 16);
+                g = Convert.ToInt32(hexString.Substring(3, 2), 16);
+                b = Convert.ToInt32(hexString.Substring(5, 2), 16);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+        else
+        {
+            return false;
+        }
+
+        _rgb = r << 24 | g << 16 | b << 8;
+        ForegroundEscapeCode = $"\x1b[38;2;{r};{g};{b}m";
+        BackgroundEscapeCode = $"\x1b[48;2;{r};{g};{b}m";
+        return true;
     }
 
     protected override object EmptyNew()
@@ -63,22 +114,12 @@ public class FontColor : DeepCloneable
 
     public static FontColor FromHex(string hexString)
     {
-        int r = 0;
-        int g = 0;
-        int b = 0;
-
-        if (!string.IsNullOrEmpty(hexString) && hexString.Length >= 6)
-        {
-            r = Convert.ToInt32(hexString.Substring(1, 2), 16);
-            g = Convert.ToInt32(hexString.Substring(3, 2), 16);
-            b = Convert.ToInt32(hexString.Substring(5, 2), 16);
-        }
-
         var fontColor = new FontColor();
-        fontColor._rgb = r << 24 | g << 16 | b << 8;
-        fontColor.ForegroundEscapeCode = $"\x1b[38;2;{r};{g};{b}m";
-        fontColor.BackgroundEscapeCode = $"\x1b[48;2;{r};{g};{b}m";
-
+        bool success = fontColor.SetHex(hexString);
+        if (!success)
+        {
+            throw new ArgumentException("Invalid hex string format. The format must be like '#61FFCA'.", nameof(hexString));
+        }
         return fontColor;
     }
 
@@ -104,21 +145,43 @@ public class FontColor : DeepCloneable
         BrightWhite,
     }
 
-    public static readonly FontColor Black = new FontColor(PresetId.Black, "\x1b[30m", "\x1b[40m");
-    public static readonly FontColor Red = new FontColor(PresetId.Red, "\x1b[31m", "\x1b[41m");
-    public static readonly FontColor Green = new FontColor(PresetId.Green, "\x1b[32m", "\x1b[42m");
-    public static readonly FontColor Yellow = new FontColor(PresetId.Yellow, "\x1b[33m", "\x1b[43m");
-    public static readonly FontColor Blue = new FontColor(PresetId.Blue, "\x1b[34m", "\x1b[44m");
-    public static readonly FontColor Magenta = new FontColor(PresetId.Magenta, "\x1b[35m", "\x1b[45m");
-    public static readonly FontColor Cyan = new FontColor(PresetId.Cyan, "\x1b[36m", "\x1b[46m");
-    public static readonly FontColor White = new FontColor(PresetId.White, "\x1b[37m", "\x1b[47m");
-    internal static readonly FontColor Default = new FontColor(PresetId.Default, "\x1b[39m", "\x1b[49m");
-    public static readonly FontColor BrightBlack = new FontColor(PresetId.BrightBlack, "\x1b[90m", "\x1b[100m");
-    public static readonly FontColor BrightRed = new FontColor(PresetId.BrightRed, "\x1b[91m", "\x1b[101m");
-    public static readonly FontColor BrightGreen = new FontColor(PresetId.BrightGreen, "\x1b[92m", "\x1b[102m");
-    public static readonly FontColor BrightYellow = new FontColor(PresetId.BrightYellow, "\x1b[93m", "\x1b[103m");
-    public static readonly FontColor BrightBlue = new FontColor(PresetId.BrightBlue, "\x1b[94m", "\x1b[104m");
-    public static readonly FontColor BrightMagenta = new FontColor(PresetId.BrightMagenta, "\x1b[95m", "\x1b[105m");
-    public static readonly FontColor BrightCyan = new FontColor(PresetId.BrightCyan, "\x1b[96m", "\x1b[106m");
-    public static readonly FontColor BrightWhite = new FontColor(PresetId.BrightWhite, "\x1b[97m", "\x1b[107m");
+    private static readonly (string ForegroundEscapeCode, string BackgroundEscapeCode)[] _presetEscapeSequenceTable = new[]
+    {
+        ("", ""), // None
+        ("\x1b[30m", "\x1b[40m"), // Black
+        ("\x1b[31m", "\x1b[41m"), // Red
+        ("\x1b[32m", "\x1b[42m"), // Green
+        ("\x1b[33m", "\x1b[43m"), // Yellow
+        ("\x1b[34m", "\x1b[44m"), // Blue
+        ("\x1b[35m", "\x1b[45m"), // Magenta
+        ("\x1b[36m", "\x1b[46m"), // Cyan
+        ("\x1b[37m", "\x1b[47m"), // White
+        ("\x1b[39m", "\x1b[49m"), // Default
+        ("\x1b[90m", "\x1b[100m"), // BrightBlack
+        ("\x1b[91m", "\x1b[101m"), // BrightRed
+        ("\x1b[92m", "\x1b[102m"), // BrightGreen
+        ("\x1b[93m", "\x1b[103m"), // BrightYellow
+        ("\x1b[94m", "\x1b[104m"), // BrightBlue
+        ("\x1b[95m", "\x1b[105m"), // BrightMagenta
+        ("\x1b[96m", "\x1b[106m"), // BrightCyan
+        ("\x1b[97m", "\x1b[107m"), // BrightWhite
+    };
+
+    public static readonly FontColor Black = new FontColor(PresetId.Black);
+    public static readonly FontColor Red = new FontColor(PresetId.Red);
+    public static readonly FontColor Green = new FontColor(PresetId.Green);
+    public static readonly FontColor Yellow = new FontColor(PresetId.Yellow);
+    public static readonly FontColor Blue = new FontColor(PresetId.Blue);
+    public static readonly FontColor Magenta = new FontColor(PresetId.Magenta);
+    public static readonly FontColor Cyan = new FontColor(PresetId.Cyan);
+    public static readonly FontColor White = new FontColor(PresetId.White);
+    internal static readonly FontColor Default = new FontColor(PresetId.Default);
+    public static readonly FontColor BrightBlack = new FontColor(PresetId.BrightBlack);
+    public static readonly FontColor BrightRed = new FontColor(PresetId.BrightRed);
+    public static readonly FontColor BrightGreen = new FontColor(PresetId.BrightGreen);
+    public static readonly FontColor BrightYellow = new FontColor(PresetId.BrightYellow);
+    public static readonly FontColor BrightBlue = new FontColor(PresetId.BrightBlue);
+    public static readonly FontColor BrightMagenta = new FontColor(PresetId.BrightMagenta);
+    public static readonly FontColor BrightCyan = new FontColor(PresetId.BrightCyan);
+    public static readonly FontColor BrightWhite = new FontColor(PresetId.BrightWhite);
 }

--- a/tests/Public/FontColor.Tests.ps1
+++ b/tests/Public/FontColor.Tests.ps1
@@ -1,0 +1,34 @@
+﻿Describe 'FontColor' {
+    BeforeEach {
+        Import-Module $PSScriptRoot/../../module/PowerShellRun -Force
+    }
+
+    It 'should be able to be set by a preset name' {
+        $option = Get-PSRunDefaultSelectorOption
+        $theme = $option.Theme
+        $theme.DefaultForegroundColor = 'Black'
+        $theme.DefaultForegroundColor -eq [PowerShellRun.FontColor]::Black | Should -BeTrue
+    }
+
+    It 'should be able to be set by a hex string' {
+        $hex = '#20F230'
+        $option = Get-PSRunDefaultSelectorOption
+        $theme = $option.Theme
+        $theme.DefaultForegroundColor = $hex
+        $theme.DefaultForegroundColor -eq [PowerShellRun.FontColor]::FromHex($hex) | Should -BeTrue
+    }
+
+    It 'should throw with an invalid string' {
+        $option = Get-PSRunDefaultSelectorOption
+        $theme = $option.Theme
+        { $theme.DefaultForegroundColor = 'abcdef' } | Should -Throw
+    }
+
+    It 'should throw with an invalid hex string' {
+        { [PowerShellRun.FontColor]::FromHex('abcdef') } | Should -Throw
+    }
+
+    AfterEach {
+        Remove-Module PowerShellRun -Force
+    }
+}


### PR DESCRIPTION
This PR adds a conversion from string to FontColor which enables the following syntax:

```powershell
$option.Theme.DefaultForegroundColor = 'Black'
$option.Theme.DefaultBackgroundColor = '#F0F2F3'
```

This features was discussed in https://github.com/mdgrs-mei/PowerShellRun/discussions/59#discussioncomment-11122079