### PR TITLE
Add conversion from string to ActionKey and RemapKey

### DIFF
--- a/src/PowerShellRun/Application/ActionKey.cs
+++ b/src/PowerShellRun/Application/ActionKey.cs
@@ -11,6 +11,17 @@ public class ActionKey : DeepCloneable
         Description = description;
     }
 
+    public ActionKey(string str)
+    {
+        var keyAndDescription = str.Split(':');
+        var key = keyAndDescription[0];
+        KeyCombination = new KeyCombination(key);
+        if (keyAndDescription.Length > 1)
+        {
+            Description = keyAndDescription[1];
+        }
+    }
+
     private ActionKey()
     {
     }

--- a/src/PowerShellRun/Application/RemapKey.cs
+++ b/src/PowerShellRun/Application/RemapKey.cs
@@ -11,6 +11,17 @@ public class RemapKey : DeepCloneable
         Destination = destination;
     }
 
+    public RemapKey(string str)
+    {
+        var sourceAndDestination = str.Split(':');
+        var source = sourceAndDestination[0];
+        Source = new KeyCombination(source);
+        if (sourceAndDestination.Length > 1)
+        {
+            Destination = new KeyCombination(sourceAndDestination[1]);
+        }
+    }
+
     private RemapKey()
     {
     }

--- a/src/PowerShellRun/Base/Key.cs
+++ b/src/PowerShellRun/Base/Key.cs
@@ -116,7 +116,7 @@ public class KeyCombination : DeepCloneable
         if (string.IsNullOrEmpty(str))
         {
             SetString();
-            return;
+            throw new ArgumentException("Can't construct KeyCombination from an empty string.");
         }
 
         var keys = str.Split('+');
@@ -147,6 +147,10 @@ public class KeyCombination : DeepCloneable
         }
 
         SetString();
+        if (_modifier == KeyModifier.None && _key == Key.None)
+        {
+            throw new ArgumentException($"Invalid string format [{str}]. The format must be like 'Ctrl+Shift+A'.");
+        }
     }
 
     internal static KeyCombination LeftArrow { get; } = new KeyCombination(KeyModifier.None, Key.LeftArrow);

--- a/tests/Public/ActionKey.Tests.ps1
+++ b/tests/Public/ActionKey.Tests.ps1
@@ -1,0 +1,18 @@
+﻿Describe 'ActionKey' {
+    BeforeEach {
+        Import-Module $PSScriptRoot/../../module/PowerShellRun -Force
+    }
+
+    It 'is set by a string' {
+        [PowerShellRun.ActionKey]$actionKey = 'A:Hello'
+        $actionKey.ToString() | Should -Be ([PowerShellRun.ActionKey]::new('A', 'Hello').ToString())
+    }
+
+    It 'should throw with an invalid string' {
+        { [PowerShellRun.ActionKey]$actionKey = 'Hello' } | Should -Throw
+    }
+
+    AfterEach {
+        Remove-Module PowerShellRun -Force
+    }
+}

--- a/tests/Public/FontColor.Tests.ps1
+++ b/tests/Public/FontColor.Tests.ps1
@@ -3,14 +3,14 @@
         Import-Module $PSScriptRoot/../../module/PowerShellRun -Force
     }
 
-    It 'should be able to be set by a preset name' {
+    It 'is set by a preset name' {
         $option = Get-PSRunDefaultSelectorOption
         $theme = $option.Theme
         $theme.DefaultForegroundColor = 'Black'
         $theme.DefaultForegroundColor -eq [PowerShellRun.FontColor]::Black | Should -BeTrue
     }
 
-    It 'should be able to be set by a hex string' {
+    It 'is set by a hex string' {
         $hex = '#20F230'
         $option = Get-PSRunDefaultSelectorOption
         $theme = $option.Theme

--- a/tests/Public/RemapKey.Tests.ps1
+++ b/tests/Public/RemapKey.Tests.ps1
@@ -1,0 +1,18 @@
+﻿Describe 'RemapKey' {
+    BeforeEach {
+        Import-Module $PSScriptRoot/../../module/PowerShellRun -Force
+    }
+
+    It 'is set by a string' {
+        [PowerShellRun.RemapKey]$remapKey = 'A:B'
+        $remapKey.ToString() | Should -Be ([PowerShellRun.RemapKey]::new('A', 'B').ToString())
+    }
+
+    It 'should throw with an invalid string' {
+        { [PowerShellRun.RemapKey]$remapKey = 'A:hello' } | Should -Throw
+    }
+
+    AfterEach {
+        Remove-Module PowerShellRun -Force
+    }
+}


### PR DESCRIPTION
This PR enables the following syntax:

```powershell
$option.KeyBinding.DefaultActionKeys = 'Enter:Quit'
$option.KeyBinding.RemapKeys = @(
    'h:LeftArrow'
    'j:DownArrow'
    'k:UpArrow'
    'l:RightArrow'
    'Shift+j:Shift+DownArrow'
    'Shift+k:Shift+UpArrow'
)
```