### PR TITLE
Support grapheme clusters

### DIFF
--- a/src/PowerShellRun.Dependency/Unicode.cs
+++ b/src/PowerShellRun.Dependency/Unicode.cs
@@ -8,13 +8,8 @@ public class Unicode
         return Wcwidth.UnicodeCalculator.GetWidth(character);
     }
 
-    public static int GetDisplayWidth(string str)
+    public static int GetDisplayWidth(int codePoint)
     {
-        int length = 0;
-        foreach (var character in str)
-        {
-            length += Wcwidth.UnicodeCalculator.GetWidth(character);
-        }
-        return length;
+        return Wcwidth.UnicodeCalculator.GetWidth(codePoint);
     }
 }

--- a/src/PowerShellRun/Application/InputBuffer.cs
+++ b/src/PowerShellRun/Application/InputBuffer.cs
@@ -1,0 +1,183 @@
+﻿namespace PowerShellRun;
+
+using System;
+using System.Globalization;
+using System.Text;
+using PowerShellRun.Dependency;
+
+internal class InputBuffer
+{
+    private StringBuilder _buffer = new StringBuilder();
+    private int[] _textElementCharIndexes = new int[0];
+    private int _cursorCharIndex = 0;
+    public bool IsQueryUpdated { get; private set; } = false;
+    public bool IsCursorUpdated { get; private set; } = false;
+
+    public string GetString()
+    {
+        return _buffer.ToString();
+    }
+
+    public bool IsEmpty()
+    {
+        return _buffer.Length == 0;
+    }
+
+    public void ClearInput()
+    {
+        _buffer.Clear();
+        UpdateTextElement();
+    }
+
+    public void ClearState()
+    {
+        IsQueryUpdated = false;
+        IsCursorUpdated = false;
+    }
+
+    private void UpdateTextElement()
+    {
+        _textElementCharIndexes = StringInfo.ParseCombiningCharacters(GetString());
+        IsQueryUpdated = true;
+    }
+
+    private int GetCharCount()
+    {
+        return _buffer.Length;
+    }
+
+    private int GetTextElementCount()
+    {
+        return _textElementCharIndexes.Length;
+    }
+
+    public void Add(char character)
+    {
+        if (_buffer.Length >= Constants.QueryCharacterMaxCount)
+            return;
+
+        if (Unicode.GetDisplayWidth(character) < 0)
+            return;
+
+        int cursorCharIndex = GetCursorCharIndex();
+        if (cursorCharIndex == _buffer.Length)
+        {
+            _buffer.Append(character);
+        }
+        else
+        {
+            _buffer.Insert(cursorCharIndex, character);
+        }
+
+        UpdateTextElement();
+        SetCursorCharIndex(cursorCharIndex + 1);
+    }
+
+    public void Add(string str)
+    {
+        foreach (char character in str)
+        {
+            Add(character);
+        }
+    }
+
+    public void Backspace()
+    {
+        if (_cursorCharIndex == 0)
+            return;
+
+        int deleteFrom = GetCharIndexFromTextElementIndex(GetCursorTextElementIndex() - 1);
+        int deleteTo = GetCursorCharIndex();
+        _buffer.Remove(deleteFrom, deleteTo - deleteFrom);
+
+        UpdateTextElement();
+        SetCursorCharIndex(deleteFrom);
+    }
+
+    public void Delete()
+    {
+        if (_cursorCharIndex == GetCharCount())
+            return;
+
+        int deleteFrom = GetCursorCharIndex();
+        int deleteTo = GetCharIndexFromTextElementIndex(GetCursorTextElementIndex() + 1);
+        _buffer.Remove(deleteFrom, deleteTo - deleteFrom);
+
+        UpdateTextElement();
+    }
+
+    public void MoveCursorForward()
+    {
+        int cursor = GetCharIndexFromTextElementIndex(GetCursorTextElementIndex() + 1);
+        SetCursorCharIndex(cursor);
+    }
+
+    public void MoveCursorBackward()
+    {
+        int cursor = GetCharIndexFromTextElementIndex(GetCursorTextElementIndex() - 1);
+        SetCursorCharIndex(cursor);
+    }
+
+    public void MoveCursorToBeginning()
+    {
+        SetCursorCharIndex(0);
+    }
+
+    public void MoveCursorToEnd()
+    {
+        SetCursorCharIndex(GetCharCount());
+    }
+
+    public int GetCursorOffsetInCanvas()
+    {
+        var str = GetString().Substring(0, GetCursorCharIndex());
+        return TextBox.GetDisplayWidth(str);
+    }
+
+    private int GetCursorTextElementIndex()
+    {
+        return GetTextElementIndexFromCharIndex(GetCursorCharIndex());
+    }
+
+    public int GetCursorCharIndex()
+    {
+        return _cursorCharIndex;
+    }
+
+    private void SetCursorCharIndex(int index)
+    {
+        _cursorCharIndex = index;
+        _cursorCharIndex = Math.Clamp(_cursorCharIndex, 0, GetCharCount());
+        IsCursorUpdated = true;
+    }
+
+    private int GetTextElementIndexFromCharIndex(int charIndex)
+    {
+        int elementIndex = GetTextElementCount();
+        if (charIndex < _buffer.Length)
+        {
+            for (var index = _textElementCharIndexes.Length - 1; index >= 0; index--)
+            {
+                if (_textElementCharIndexes[index] <= charIndex)
+                {
+                    elementIndex = index;
+                    break;
+                }
+            }
+        }
+        return elementIndex;
+    }
+
+    private int GetCharIndexFromTextElementIndex(int textElementIndex)
+    {
+        if (textElementIndex < 0)
+            return 0;
+
+        if (textElementIndex >= _textElementCharIndexes.Length)
+            return _buffer.Length;
+
+        return _textElementCharIndexes[textElementIndex];
+    }
+
+
+}

--- a/src/PowerShellRun/Application/SearchBar.cs
+++ b/src/PowerShellRun/Application/SearchBar.cs
@@ -203,6 +203,9 @@ internal class SearchBar
             if (key.IsRemapped)
                 continue;
 
+            if (key.ConsoleKeyInfo.KeyChar == '\0')
+                continue;
+
             _inputBuffer.Add(key.ConsoleKeyInfo.KeyChar);
         }
     }

--- a/src/PowerShellRun/Application/Searcher.cs
+++ b/src/PowerShellRun/Application/Searcher.cs
@@ -1,6 +1,7 @@
 ﻿namespace PowerShellRun;
 using System;
 using System.Linq;
+using System.Text;
 
 internal class Searcher
 {
@@ -55,10 +56,14 @@ internal class Searcher
 
     private void AddScores(InternalEntry[] entries, string query, ScoreOperation operation)
     {
-        bool useLowerCase = false;
-        if (!query.Any(x => Char.IsUpper(x)))
+        bool isQueryAllLowerCase = true;
+        foreach (Rune rune in query.EnumerateRunes())
         {
-            useLowerCase = true;
+            if (Rune.IsUpper(rune))
+            {
+                isQueryAllLowerCase = false;
+                break;
+            }
         }
 
         foreach (var entry in entries)
@@ -66,8 +71,8 @@ internal class Searcher
             if (operation == ScoreOperation.And && entry.Score == 0)
                 continue;
 
-            string nameEntry = useLowerCase ? entry.SearchNameLowerCase : entry.SearchName;
-            string descriptionEntry = useLowerCase ? entry.SearchDescriptionLowerCase : entry.SearchDescription;
+            string nameEntry = isQueryAllLowerCase ? entry.SearchNameLowerCase : entry.SearchName;
+            string descriptionEntry = isQueryAllLowerCase ? entry.SearchDescriptionLowerCase : entry.SearchDescription;
 
             int nameScore = CalculateScore(
                 nameEntry,

--- a/src/PowerShellRun/UI/Canvas.cs
+++ b/src/PowerShellRun/UI/Canvas.cs
@@ -322,7 +322,14 @@ internal sealed class Canvas : Singleton<Canvas>
                     builder.Append(escapeSequence);
                 }
 
-                builder.Append(cell.Character);
+                if (cell.TextElement is not null)
+                {
+                    builder.Append(cell.TextElement);
+                }
+                else
+                {
+                    builder.Append(cell.Character);
+                }
             }
             builder.Append('\n');
         }

--- a/src/PowerShellRun/UI/CanvasCell.cs
+++ b/src/PowerShellRun/UI/CanvasCell.cs
@@ -12,9 +12,13 @@ internal class CanvasCell
         ForceResetFont = 1 << 0,
         ForceResetFontNext = 1 << 1,
         EscapeSequenceLowPriority = 1 << 2,
+        SecondCellOfWideCharacter = 1 << 3,
     }
 
+    // base characters
     public char Character { get; set; }
+    // surrogate pairs or combining character sequences
+    public string? TextElement { get; set; }
     public string? EscapeSequence { get; set; }
     public FontColor? ForegroundColor { get; set; }
     public FontColor? BackgroundColor { get; set; }
@@ -29,6 +33,7 @@ internal class CanvasCell
     public void Clear()
     {
         Character = ' ';
+        TextElement = null;
         EscapeSequence = null;
         ForegroundColor = null;
         BackgroundColor = null;
@@ -39,6 +44,7 @@ internal class CanvasCell
     public void CopyTo(CanvasCell cell)
     {
         cell.Character = Character;
+        cell.TextElement = TextElement;
         cell.EscapeSequence = EscapeSequence;
         cell.ForegroundColor = ForegroundColor;
         cell.BackgroundColor = BackgroundColor;
@@ -54,6 +60,22 @@ internal class CanvasCell
         Option optionFlags)
     {
         Character = character;
+        TextElement = null;
+        ForegroundColor = foregroundColor;
+        BackgroundColor = backgroundColor;
+        FontStyle = fontStyle;
+        OptionFlags = optionFlags;
+    }
+
+    public void SetTextElement(
+        string textElement,
+        FontColor? foregroundColor,
+        FontColor? backgroundColor,
+        FontStyle fontStyle,
+        Option optionFlags)
+    {
+        Character = ' ';
+        TextElement = textElement;
         ForegroundColor = foregroundColor;
         BackgroundColor = backgroundColor;
         FontStyle = fontStyle;


### PR DESCRIPTION
This PR adds support for [grapheme clusters](https://learn.microsoft.com/en-us/dotnet/standard/base-types/character-encoding-introduction#grapheme-clusters). It calculates the display width of surrogate pairs and combining character sequences correctly.
Fixes #63.

The border rendering does not break with the following code which proves that the width calculation is correct.

```powershell
$option = Get-PSRunDefaultSelectorOption
$option.Theme.Cursor = '👉🏻 ' # 1F449, 1F3FB
$option.Theme.Marker = '🙋‍♂️' # 1F64B, 200D(ZWJ), 2642, FE0F(Variation Selector)
$option.Prompt = 'Can you render these 🤷‍♂️?' # 1F937, 200D(ZWJ), 2642, FE0F(Variation Selector)
Set-PSRunDefaultSelectorOption $option

'A', '𐓏', '😁', 'á', '👩🏽‍🚒', 'パ', '葛󠄀', '🧑🏻‍💻', '👨‍👩‍👧‍👦' | Invoke-PSRunSelector -Expression { @{
        Name = $_
        Preview = @(
            'A    0041 - ASCII'
            '𐓏    D801, DCCF - Surrogate Pair w=1'
            '😁   D83D, DE01 - Surrogate Pair w=2'
            'á    0061, 0301 - Combining Acute Accent w=1'
            'パ   30CF, 309A - Combining Katakana-Hiragana Semi-Voiced Sound Mark w=2'
            '葛󠄀   845B, DB40, DD00 - Variation Selector w=2'
            '👩🏽‍🚒   1F469, 1F3FD, 200D(ZWJ), 1F692 - Combining Character Sequence w=2'
            '🧑🏻‍💻   1F9D1, 1F3FB, 200D(ZWJ), 1F4BB - Combining Character Sequence w=2'
            '👨‍👨‍👧‍👦   1F468, 200D(ZWJ), 1F468, 200D(ZWJ), 1F467, 200D(ZWJ), 1F466 - Combining Character Sequence w=2'
        )
    } } -MultiSelection
```

![image](https://github.com/user-attachments/assets/09d09554-e5c7-4f1c-88fa-23bae1ddd4e4)
