### PR TITLE
Move to .NET 8

### DIFF
--- a/.github/workflows/pester-test.yml
+++ b/.github/workflows/pester-test.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup dotnet
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.0.200'
+          dotnet-version: '8.0.404'
       - name: Build
         shell: pwsh
         run: |

--- a/.github/workflows/publish-module.yml
+++ b/.github/workflows/publish-module.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup dotnet
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.0.200'
+          dotnet-version: '8.0.404'
       - name: Build
         shell: pwsh
         run: |

--- a/Build.ps1
+++ b/Build.ps1
@@ -3,7 +3,7 @@ param (
     [String]$Configuration = 'Debug'
 )
 
-$netVersion = 'net6.0'
+$netVersion = 'net8.0'
 $copyExtensions = @('.dll', '.pdb')
 $src = "$PSScriptRoot/src"
 $coreSrc = "$src/PowerShellRun"

--- a/module/PowerShellRun/PowerShellRun.psm1
+++ b/module/PowerShellRun/PowerShellRun.psm1
@@ -1,5 +1,5 @@
 
-$netVersion = 'net6.0'
+$netVersion = 'net8.0'
 $dll = "$PSScriptRoot/bin/$netVersion/PowerShellRun.dll"
 Import-Module $dll
 

--- a/src/PowerShellRun.Dependency/PowerShellRun.Dependency.csproj
+++ b/src/PowerShellRun.Dependency/PowerShellRun.Dependency.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>PowerShellRun.Dependency</AssemblyName>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/PowerShellRun/PowerShellRun.csproj
+++ b/src/PowerShellRun/PowerShellRun.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>PowerShellRun</AssemblyName>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\PowerShellRun.Dependency\PowerShellRun.Dependency.csproj" />
-    <PackageReference Include="System.Management.Automation" Version="7.2.0" PrivateAssets="all" />
+    <PackageReference Include="System.Management.Automation" Version="7.4.0" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/tests/RestartableSession.ps1
+++ b/tests/RestartableSession.ps1
@@ -3,7 +3,6 @@
 $root = Split-Path $PSScriptRoot -Parent
 Enter-RSSession -OnStart {
     $root = $args[0]
-    $netVersion = 'net6.0'
     $build = "$root/Build.ps1"
 
     & $build Debug


### PR DESCRIPTION
Since the minimum pwsh version is 7.4 now, we should also move to .NET8.