### PR TITLE
Add alias ./ to File Manager (PSRun)

### DIFF
--- a/module/PowerShellRun/Private/FileSystemRegistry.ps1
+++ b/module/PowerShellRun/Private/FileSystemRegistry.ps1
@@ -84,7 +84,7 @@ class FileSystemRegistry : EntryRegistry {
 
         $entry = [PowerShellRun.SelectorEntry]::new()
         $entry.Icon = '🔍'
-        $entry.Name = 'File Manager (PSRun)'
+        $entry.Name = 'File Manager (PSRun) ./'
         $entry.Description = 'Navigate file system with PowerShellRun based on the current directory'
         $entry.ActionKeys = @(
             [PowerShellRun.ActionKey]::new($script:globalStore.firstActionKey, 'Explore current directory')


### PR DESCRIPTION
As a functionality, `File Manager (PSRun)` is the same as the Favorite folder entry for the current directory. This PR adds `./` to the File Manager name so that it can be searched by `./`.

![image](https://github.com/user-attachments/assets/a96a6ae1-1db1-4c15-8e8c-1362aed76261)
